### PR TITLE
Update components.yaml

### DIFF
--- a/api-specificatie/components.yaml
+++ b/api-specificatie/components.yaml
@@ -105,6 +105,7 @@ Nen3610Id:
       type: string
       title: Versie
       description: Versie-aanduiding van een object
+# Onderstaand component 'Foutbericht' kan gebruikt worden voor alle op https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html gedefinieerde statuscodes.
 Foutbericht:
   type: object
   description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).


### PR DESCRIPTION
In remark een link opgenomen naar de W3C definitie van alle HTTP statuscodes als voorbereiding op een door Johan Boer uit te voeren wijziging.
Hij gaat het daaronder staande component 'Foutbericht' vervangen door een specifiek bericht per benodigde statuscode. Zodat bij een Foutbericht voor de statuscode 401 bijv. ook een daarop geënt example wordt gedefinieerd.