### PR TITLE
Geen maximaal aantal meegeven, want dat hangt af van de bron

### DIFF
--- a/features/foutafhandeling.feature
+++ b/features/foutafhandeling.feature
@@ -15,7 +15,7 @@ Functionaliteit: Afhandeling van fouten
   | Geen parameter is meegegeven       | 400    | Ten minste één parameter moet worden opgegeven.               | paramsRequired    |
   | Verplichte parameter(combinatie)   | 400    | Minimale combinatie van parameters moet worden opgegeven.     | paramsCombination |
   | Parametervalidatie                 | 400    | Een of meerdere parameters zijn niet correct.                 | paramsValidation  |
-  | Teveel zoekresultaten              | 400    | Teveel zoekresultaten (meer dan {maximaal aantal}).           | tooManyResults    |
+  | Teveel zoekresultaten              | 400    | Teveel zoekresultaten.                                        | tooManyResults    |
   | Niet geauthenticeerd               | 401    | Niet correct geauthenticeerd.                                 | authentication    |
   | Geen autorisatie voor operatie     | 403    | U bent niet geautoriseerd voor deze operatie.                 | autorisation      |
   | Opgevraagde resource bestaat niet  | 404    | Opgevraagde resource bestaat niet.                            | notFound          |


### PR DESCRIPTION
voor de interne bron (gegevensmagazijn) kan een ander maximum aantal worden gehanteerd dan voor de externe bron (GBA-V). GBA-V heeft maximum van 10 voor normaal zoeken en 30 voor adres zoeken.