### PR TITLE
Add files via upload

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -1,0 +1,320 @@
+openapi: '3.0.0'
+info:
+  title: Generieke componenten voor Haal Centraal APIs
+  version: '1.0'
+components:
+  headers:
+    api_version:
+      schema:
+        type: string
+        description: Geeft een specifieke API-versie aan in de context van een specifieke aanroep.
+        example: 1.0.1
+    warning:
+      schema:
+        type: string
+        description: 'zie RFC 7234. In het geval een major versie wordt uitgefaseerd, gebruiken we warn-code 299 ("Miscellaneous Persistent Warning") en het API end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd door de warn-text met de human-readable waarschuwing'
+        example: '299 https://service.../api/.../v1 "Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1".'
+    X_Rate_Limit_Limit:
+      schema:
+        type: integer
+    X_Rate_Limit_Remaining:
+      schema:
+        type: integer
+    X_Rate_Limit_Reset:
+      schema:
+        type: integer
+  parameters:
+    api-version:
+      name: api-version
+      in: header
+      required: false
+      description: "Bevat de versie van de aan te roepen API conform [Landelijke API-strategie](https://geonovum.github.io/KP-APIs/#versioning)."
+      schema:
+        type: string
+        example: 1.0.1
+    expand:
+      name: expand
+      in: query
+      required: false
+      description: "Hier kan aangegeven worden welke gerelateerde resources meegeladen moeten worden. Resources en velden van resources die gewenst zijn kunnen in de expand parameter kommagescheiden worden opgegeven. Specifieke velden van resource kunnen worden opgegeven door het opgeven van de resource-naam gevolgd door de veldnaam, met daartussen een punt. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/expand.feature)"
+      schema:
+        type: string
+    fields:
+      name: fields
+      in: query
+      required: false
+      description: "Geeft de mogelijkheid de inhoud van de body van het antwoord naar behoefte aan te passen. Bevat een door komma's gescheiden lijst van veldennamen. Als niet-bestaande veldnamen worden meegegeven wordt een 400 Bad Request teruggegeven. Wanneer de parameter fields niet is opgenomen, worden alle gedefinieerde velden die een waarde hebben teruggegeven. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/blob/master/features/fields.feature)"
+      schema:
+        type: string
+    uuid:
+      name: uuid
+      in: path
+      description: "Een UUID is een nummer van 128 bits (= 16 bytes). UUID wordt weergegeven in 32 ??hexadecimale cijfers. Deze cijfers zijn ingedeeld in vijf groepen, in ongelijk aantal en gescheiden door koppeltekens: 8-4-4-4-12 In zijn geheel wordt een UUID dus door 36 tekens gevormd, waarvan 32 hexadecimale karakters en vier streepjes: 550e8400-e29b-41d4-a716-446655440000"
+      required: true
+      schema:
+        type: string
+        maxLength: 36
+  responses:
+    '400':
+      description: Bad Request
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            allOf:
+            - $ref: '#/components/schemas/Foutbericht'
+            - type: object
+              properties:
+                invalid-params:
+                  description: Foutmelding per fout in een parameter. Alle gevonden fouten worden één keer teruggemeld.
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InvalidParams'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.1 400 Bad Request
+            title: Ten minste één parameter moet worden opgegeven.
+            status: 400
+            detail: The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modification.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: paramsRequired
+            invalid-params:
+              - type: https://www.vng.nl/realisatie/api/validaties/integer
+                name: verblijfplaats__huisnummer
+                code: integer
+                reason: Waarde is geen geldige integer.
+    '401':
+      description: Unauthorized
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.2 401 Unauthorized
+            title: Niet correct geauthenticeerd.
+            status: 401
+            detail: The request requires user authentication. The response MUST include a WWW-Authenticate header field (section 14.47) containing a challenge applicable to the requested resource.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: authentication
+    '403':
+      description: Forbidden
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.4 403 Forbidden
+            title: U bent niet geautoriseerd voor deze operatie.
+            status: 403
+            detail: The server understood the request, but is refusing to fulfill it.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: autorisation
+    '404':
+      description: Not Found
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.5 404 Not Found
+            title: Opgevraagde resource bestaat niet.
+            status: 404
+            detail: The server has not found anything matching the Request-URI.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notFound
+    '406':
+      description: Not Acceptable
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.7 406 Not Acceptable
+            title: Gevraagde contenttype wordt niet ondersteund.
+            status: 406
+            detail: The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notAcceptable
+    '409':
+      description: Conflict
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict
+            title: Conflict
+            status: 409
+            detail: The request could not be completed due to a conflict with the current state of the resource
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: conflict
+    '410':
+      description: Gone
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone
+            title: Gone
+            status: 410
+            detail: The request could not be completed due to a conflict with the current state of the resource
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: gone
+    '415':
+      description: Unsupported Media Type
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type
+            title: Unsupported Media Type
+            status: 415
+            detail: The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: unsupported
+    '429':
+      description: Too Many Requests
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+            title: Too many request
+            status: 429
+            detail: The user has sent too many requests in a given amount of time (rate limiting).
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: tooManyRequests
+    '500':
+      description: Internal Server Error
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.1 500 Internal server error
+            title: Interne server fout.
+            status: 500
+            detail: The server encountered an unexpected condition which prevented it from fulfilling the request.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: serverError
+    '503':
+      description: Service Unavailable
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+          example:
+            type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.5.4 503 Service Unavailable
+            title: Bronservice {bron} is niet beschikbaar.
+            status: 503
+            detail: The service is currently unable to handle the request due to a temporary overloading or maintenance of the server.
+            instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
+            code: notImplemented
+    'default':
+      description: Er is een onverwachte fout opgetreden
+      headers:
+        api-version:
+          $ref: "#/components/headers/api_version"
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Foutbericht'
+  schemas:
+    Href:
+      type: string
+      format: "uri"
+      example: "datapunt.voorbeeldgemeente.nl/api/resourcename/123456789"
+    HalLink:
+      type: object
+      properties:
+        href:
+          $ref: "#/components/schemas/Href"
+    HalCollectionLinks:
+      type: object
+      properties:
+        self:
+          type: object
+          description: "uri van de api aanroep die tot dit resultaat heeft geleid"
+          properties:
+            href:
+              $ref: "#/components/schemas/Href"
+    Foutbericht:
+      type: object
+      description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).
+      properties:
+        type:
+          type: string
+          format: uri
+          description: Link naar meer informatie over deze fout
+        title:
+          type: string
+          description: Beschrijving van de fout
+        status:
+          type: integer
+          description: Http status code
+        detail:
+          type: string
+          description: Details over de fout
+        instance:
+          type: string
+          format: uri
+          description: Uri van de aanroep die de fout heeft veroorzaakt
+        code:
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          minLength: 1
+    InvalidParams:
+      type: object
+      description: Details over fouten in opgegeven parameters
+      properties:
+        type:
+          type: string
+          format: uri
+          example: https://www.vng.nl/realisatie/api/validaties/integer
+        name:
+          type: string
+          description: Naam van de parameter
+          example: verblijfplaats__huisnummer
+        code:
+          type: string
+          description: Systeemcode die het type fout aangeeft
+          minLength: 1
+          example: integer
+        reason:
+          type: string
+          description: Beschrijving van de fout op de parameterwaarde
+          example: Waarde is geen geldige integer.


### PR DESCRIPTION
Ik wil een aantal verbeteringen voorstellen. In plaats van de verschillende generieke yaml bestanden (components, headers, parameters) is het mogelijk om een domain library te definieren. Dat is een yaml bestand waar generieke components (schemas, headers, parameters, responses, etc) kan worden gedefinieerd en worden hergebruikt in andere yaml bestanden.
Verder zag ik dat de foutberichten bijna allemaal hetzelfde zijn. Het verschil tussen de foutberichten is eigenlijk alleen de example teksten. In OpenApi is het mogelijk om een example te specificeren. Hierdoor is het mogelijk om voor de verschillende fout responses hetzelfde Foutbericht te referencen en een specifieke example te specificeren.
Deze verbeteringen staan verwerkt in het mee geuploade common.yaml bestand. Mocht dit voor jullie de way to go zijn, dan moet de referencen in de andere yaml bestanden hierop worden aangepast