### PR TITLE
Update common.yaml

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -267,11 +267,7 @@ components:
       type: object
       properties:
         self:
-          type: object
-          description: "uri van de api aanroep die tot dit resultaat heeft geleid"
-          properties:
-            href:
-              $ref: "#/components/schemas/Href"
+          $ref: "#/components/schemas/HalLink"
     Foutbericht:
       type: object
       description: Terugmelding bij een fout. JSON representatie in lijn met [RFC7807](https://tools.ietf.org/html/rfc7807).


### PR DESCRIPTION
De self property van HalCollectionLinks is een HalLink. Om die reden is het vervangen. Bijkomend voordeel: er wordt 1 extra class (self) minder gegenereerd