### PR TITLE
aanpassingen naamgebruik features

### DIFF
--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -19,7 +19,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
   Voor een persoon zonder adellijke titel of predicaat begint de briefaanhef met “Geachte mevrouw” of “Geachte heer”, afhankelijk van het geslacht van de persoon. Hierop volgt de samengestelde naam.
   De waarde van aanduidingNaamgebruik bepaalt hoe de aanhef wordt samengesteld uit de naam van de persoon en de naam van de partner.
 
-  Het voorvoegsel van de eerste geslachtsnaam in de briefaanhef wordt met een hoofdletter geschreven. Het voorvoegsel van de tweede geslachtsnaam wordt met een kleine letter geschreven.
+  Het voorvoegsel van de eerste geslachtsnaam in de briefaanhef wordt met een hoofdletter geschreven.
 
   Wanneer de persoon een adellijke titel of predikaat heeft, wordt de aanhef volgens de volgende tabel:
   | adellijkeTitel_predikaat | Aanhef                |
@@ -41,30 +41,36 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
   Dan wordt de adellijke titel dan wel het predicaat niet gebruikt,
   En de persoon wordt dan aangesproken met “Geachte mevrouw” of “Geachte heer” gevolgd door voorvoegsel en geslachtsnaam van de partner.
 
-  Als betrokkene een predikaat heeft (jonkvrouw of jonkheer)
-  En betrokkene is getrouwd of geregistreerd partnerschap of is getrouwd geweest of heeft geregistreerd partnerschap gehad
+  Als betrokkene het predikaat jonkvrouw heeft
+  En betrokkene is getrouwd of heeft een geregistreerd partnerschap
   Dan wordt het predikaat niet gebruikt
-  En de persoon wordt dan aangesproken met “Geachte mevrouw” of “Geachte heer” gevolgd door de samengestelde naam
+  En de persoon wordt dan aangesproken met “Geachte mevrouw” gevolgd door de samengestelde naam
 
-  Als betrokkene geen adellijke titel of predicaat heeft
-  En de echtgenoot/partner wel een adellijke titel heeft
-  En de adellijke titel van de partner heeft een equivalent voor het geslacht van de partner
-  En de echtgenoot/partner heeft niet hetzelfde geslacht als betrokkene
+  Als betrokkene het predikaat jonkvrouw heeft
+  En betrokkene is getrouwd geweest of heeft een geregistreerd partnerschap gehad
+  En het huwelijk dan wel geregistreerd partnerschap is ontbonden
+  En de partnernaam wordt niet (meer) gebruikt (aanduiding naamgebruik is "E")
+  Dan wordt het predikaat gebruikt als was zij nooit getrouwd geweest
+
+  Als betrokkene het predikaat jonkvrouw heeft
+  En betrokkene is getrouwd geweest of heeft een geregistreerd partnerschap gehad
+  En het huwelijk dan wel geregistreerd partnerschap is ontbonden
+  En de (ex)partnernaam wordt nog gebruikt (aanduiding naamgebruik is "V", "N" of "P")
+  Dan wordt het predikaat niet gebruikt
+  En de persoon wordt dan aangesproken met “Geachte mevrouw” gevolgd door de samengestelde naam
+
+  Als een vrouw als partner of echtgenoot een man met adellijke titel heeft
+  En deze adellijke titel heeft een vrouwelijke vorm (zie tabel hieronder)
   En betrokkene gebruikt de naam van de partner
-  Dan wordt de briefaanhef van de partner gebruikt in de vorm voor het geslacht van betrokkene:
+  Dan wordt de aanhef afhankelijk van de adellijke titel van de partner:
   | adellijkeTitel_predikaat partner | Aanhef                |
   | Baron                            | Hoogwelgeboren vrouwe |
-  | Barones                          | Hoogwelgeboren heer   |
   | Graaf                            | Hooggeboren vrouwe    |
-  | Gravin                           | Hooggeboren heer      |
   | Hertog                           | Hoogwelgeboren vrouwe |
-  | Hertogin                         | Hoogwelgeboren heer   |
   | Markies                          | Hoogwelgeboren vrouwe |
-  | Markiezin                        | Hoogwelgeboren heer   |
   | Prins                            | Hoogheid              |
-  | Prinses                          | Hoogheid              |
 
-  In alle andere gevallen heeft de adellijke titel of het predicaat van de partner van de persoon geen invloed op de aanhef.
+  In alle andere gevallen heeft de adellijke titel of het predicaat van de partner geen invloed op de aanhef.
 
   Als er meerdere actuele (niet ontbonden) huwelijken/partnerschappen zijn
   En de aanschijfwijze is ongelijk aan 'Eigen'
@@ -73,7 +79,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
   Als er meerdere ontbonden huwelijken/partnerschappen zijn
   En er geen actueel (niet ontbonden) huwelijk/partnerschap is
   En de aanschijfwijze is ongelijk aan 'Eigen'
-  Dan wordt als partnernaam de naam van de laatst ontbinden relatie gebruikt.
+  Dan wordt als partnernaam de naam van de laatst ontbonden relatie gebruikt.
 
 
   Abstract Scenario: De aanhef wordt samengesteld op basis van geslachtsaanduiding en naamgegevens van de persoon en de partner
@@ -111,13 +117,21 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
       | Ridder                   | Eigen                 | M. ridder van Hoogh                         | Hoogwelgeboren heer       |
 
     Voorbeelden: predikaat
-      | adellijkeTitel_predikaat | soortVerbintenis | Ontbinding huwelijk/geregistreerd partnerschap | aanhef                    |
-      | Jonkheer                 | Geen             | Geen                                           | Hoogwelgeboren heer       |
-      | Jonkvrouw                | Geen             | Geen                                           | Hoogwelgeboren vrouwe     |
-      | Jonkheer                 | Huwelijk         | Niet                                           | Geachte heer Van Hoogh    |
-      | Jonkheer                 | Partnerschap     | Niet                                           | Geachte heer Van Hoogh    |
-      | Jonkheer                 | Huwelijk         | Ja                                             | Geachte heer Van Hoogh    |
-      | Jonkheer                 | Huwelijk         | Niet                                           | Geachte heer Van Hoogh    |
+      | adellijkeTitel_predikaat | aanduidingNaamgebruik | partner | Ontbinding huwelijk/geregistreerd partnerschap | aanhef                                 |
+      | Jonkheer                 | Eigen                 | Geen    | Geen                                           | Hoogwelgeboren heer                    |
+      | Jonkheer                 | Eigen                 | Ja      | Geen                                           | Hoogwelgeboren heer                    |
+      | Jonkheer                 | Partner na eigen      | Ja      | Geen                                           | Hoogwelgeboren heer                    |
+      | Jonkheer                 | Partner               | Ja      | Geen                                           | Hoogwelgeboren heer                    |
+      | Jonkheer                 | Partner voor eigen    | Ja      | Geen                                           | Hoogwelgeboren heer                    |
+      | Jonkvrouw                | Eigen                 | Geen    | Geen                                           | Hoogwelgeboren vrouwe                  |
+      | Jonkvrouw                | Eigen                 | Ja      | Geen                                           | Geachte mevrouw Van Hoogh              |
+      | Jonkvrouw                | Partner na eigen      | Ja      | Geen                                           | Geachte mevrouw Van Hoogh-van der Veen |
+      | Jonkvrouw                | Partner               | Ja      | Geen                                           | Geachte mevrouw Van der Veen-van Hoogh |
+      | Jonkvrouw                | Partner voor eigen    | Ja      | Geen                                           | Geachte mevrouw Van der Veen           |
+      | Jonkvrouw                | Eigen                 | Ja      | Ja                                             | Hoogwelgeboren vrouwe                  |
+      | Jonkvrouw                | Partner na eigen      | Ja      | Ja                                             | Geachte mevrouw Van Hoogh-van der Veen |
+      | Jonkvrouw                | Partner               | Ja      | Ja                                             | Geachte mevrouw Van der Veen-van Hoogh |
+      | Jonkvrouw                | Partner voor eigen    | Ja      | Ja                                             | Geachte mevrouw Van der Veen           |
 
     Voorbeelden: partner heeft adellijke titel of predikaat
       | geslachtsaanduiding | geslachtsaanduiding partner | adellijkeTitel_predikaat partner | aanduidingNaamgebruik | aanschrijfwijze | aanhef |
@@ -126,10 +140,11 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
       | V | M | Baron    | Partner               | A.C. barones van den Aedel              | Hoogwelgeboren vrouwe                      |
       | V | M | Baron    | Partner voor eigen    | A.C. barones van den Aedel-van der Veen | Hoogwelgeboren vrouwe                      |
       | M | V | Gravin   | Eigen                 | W. van der Veen                         | Geachte heer Van der Veen                  |
-      | M | V | Gravin   | Partner na eigen      | W. van der Veen-graaf van den Aedel     | Hooggeboren heer                           |
-      | M | V | Gravin   | Partner               | W. graaf van den Aedel                  | Hooggeboren heer                           |
-      | M | V | Gravin   | Partner voor eigen    | W. graaf van den Aedel-van der Veen     | Hooggeboren heer                           |
+      | M | V | Gravin   | Partner na eigen      | W. van der Veen-van den Aedel           | Geachte heer Van der Veen-van den Aedel    |
+      | M | V | Gravin   | Partner               | W. van den Aedel                        | Geachte heer Van den Aedel                 |
+      | M | V | Gravin   | Partner voor eigen    | W. van den Aedel-van der Veen           | Geachte heer Van den Aedel-van der Veen    |
       | M | M | Baron    | Partner na eigen      | W. van der Veen-van den Aedel           | Geachte heer Van der Veen-van den Aedel    |
+      | V | V | Barones  | Partner na eigen      | W. van der Veen-van den Aedel           | Geachte mevrouw Van der Veen-van den Aedel |
       | V | M | Ridder   | Partner na eigen      | W. van der Veen-van den Aedel           | Geachte mevrouw Van der Veen-van den Aedel |
       | V | M | Ridder   | Partner               | W. van den Aedel                        | Geachte mevrouw Van den Aedel              |
       | V | M | Jonkheer | Eigen                 | A.C. van der Veen                       | Geachte mevrouw Van der Veen               |

--- a/features/aanschrijfwijze.feature
+++ b/features/aanschrijfwijze.feature
@@ -2,7 +2,7 @@
 
 # User story #13
 Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze van mijn burgers
-  Attribuut aanschrijfwijze bij een ingeschreven persoon wordt gevuld door de provider om op deze wijze op eenduidige wijze een persoon te kunnen aanschrijven. Bij het samenstellen van de aanschrijfwijze worden academische titels voorAlsnog niet opgenomen. Academische titels zijn geen authentiek gegeven en daarom buiten scope geplaatst.
+  Attribuut aanschrijfwijze bij een ingeschreven persoon wordt gevuld door de provider om op deze wijze op eenduidige wijze een persoon te kunnen aanschrijven. Bij het samenstellen van de aanschrijfwijze worden academische titels vooralsnog niet opgenomen. Academische titels zijn geen authentiek gegeven en daarom buiten scope geplaatst.
   De aanschrijfwijze wordt gebruikt als eerste regel in de adressering op een envelop, of links bovenaan een brief, direct boven het adres.
   De aanschrijfwijze kan ook worden gebruikt in lijsten met zoekresultaten, of op een website om te tonen op wie het betrekking heeft.
 
@@ -22,8 +22,6 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
 
   Wanneer er geen voorvoegsel is, wordt deze niet opgenomen. Er zit dan één spatie tussen de voorletters en de geslachtsnaam. Zie de tabel "Voorbeelden: met voorvoegsel" en "Voorbeelden: met voorvoegsel" hieronder.
 
-  Een voorvoegsel van zowel betrokkene als van de partner wordt geschreven in kleine letters.
-
   De voorletters worden opgenomen zoals beschreven in Voorletters.feature.
 
   Als er meerdere actuele (niet ontbonden) huwelijken/partnerschappen zijn
@@ -37,7 +35,14 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
 
   Op basis van attribuut adellijkeTitel_predikaat wordt het de adelijke titel of het predikaat toegevoegd in de aanschrijfwijze. Zie ook de tabel "Voorbeelden: adelijke titels en predikaat" hieronder.
   Als de betrokkene beschikt over een predikaat
+  En de aanduiding aanschrijving is gelijk aan "E" (eigen) of "N" (partner na eigen geslachtsnaam)
   Dan wordt deze geplaatst vóór de voorletters.
+  Als de betrokkene beschikt over een predikaat
+  En de aanduiding aanschrijving is gelijk aan "V" (partner voor eigen geslachtsnaam)
+  Dan wordt deze geplaatst vóór het eigen voorvoegsel en geslachtsnaam.
+  Als de betrokkene beschikt over een predikaat
+  En de aanduiding aanschrijving is gelijk aan "P" (partner)
+  Dan wordt het predikaat niet gebruikt.
   Als de betrokkene over een adelijke titel beschikt
   Dan wordt de adelijke titel geplaatst tussen voorletters en achternaam (voorvoegsel en geslachtsnaam).
   Als de betrokkene beschikt over een predikaat of adelijke titel
@@ -48,9 +53,6 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
   Als betrokkene zelf beschikt over een adellijke titel
   En betrokkene de geslachtsnaam van de echtgenoot/partner gebruikt zonder de eigen geslachtsnaam
   Dan wordt de adellijke titel niet gebruikt.
-  Als betrokkene een predikaat heeft (jonkvrouw of jonkheer)
-  En betrokkene is getrouwd of geregistreerd partnerschap of is getrouwd geweest of heeft geregistreerd partnerschap gehad
-  Dan wordt het predikaat niet gebruikt.
   Als een vrouw als partner of echtgenoot een man met adellijke titel heeft
   En deze adellijke titel heeft een vrouwelijke vorm (zie tabel hieronder)
   Dan wordt die adellijke titel in vrouwelijke vorm opgenomen wanneer ze de naam van haar partner gebruikt.
@@ -59,14 +61,9 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
   | Baron	| barones          |
   | Prins	| prinses          |
 
-  Als een man als partner of echtgenote een vrouw met adellijke titel heeft
-  Dan wordt die adellijke titel in mannelijke vorm opgenomen wanneer hij de naam van haar partner gebruikt.
-  | Titel   | Mannelijke vorm |
-  | Gravin	| graaf           |
-  | Barones	| baron           |
-  | Prinses	| prins           |
-
   Als betrokkene en partner hetzelfde geslacht hebben Of de titel van de partner komt niet voor in bovenstaande tabellen (er is geen vrouwelijke vorm van de titel)
+  Dan wordt de adellijke titel van de partner niet opgenomen.
+  Als betrokkene een man is
   Dan wordt de adellijke titel van de partner niet opgenomen.
 
   Abstract Scenario: De aanschrijfwijze wordt samengesteld op basis van aanduidingAanschrijving en naamgegevens van de persoon en de partner
@@ -105,36 +102,41 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
       | V | VL VP GP-AT VV GN | Aedel | Emma Louise    | E.L. van der Veen-gravin van den Aedel |
 
     Voorbeelden: betrokkene heeft een predikaat en partner heeft geen adellijke titel
-      | adellijkeTitel_predikaat | aanduidingNaamgebruik | soortVerbintenis | Ontbinding huwelijk/geregistreerd partnerschap | aanschrijfwijze          |
-      | Jonkheer                 | Eigen                 | Geen             | Geen                                           | jonkheer T. van Hoogh    |
-      | Jonkvrouw                | Eigen                 | Geen             | Geen                                           | jonkvrouw T. van Hoogh   |
-      | Jonkheer                 | Eigen                 | Huwelijk         | Niet                                           | T. van Hoogh             |
-      | Jonkheer                 | Eigen                 | Partnerschap     | Niet                                           | T. van Hoogh             |
-      | Jonkheer                 | Eigen                 | Huwelijk         | Ja                                             | T. van Hoogh             |
-      | Jonkvrouw                | Eigen                 | Huwelijk         | Niet                                           | T. van Hoogh             |
-      | Jonkvrouw                | Partner na eigen      | Huwelijk         | Niet                                           | T. van Hoogh-in het Veld |
-      | Jonkvrouw                | Partner               | Huwelijk         | Niet                                           | T. in het Veld           |
-      | Jonkvrouw                | Partner voor eigen    | Huwelijk         | Niet                                           | T. in het Veld-van Hoogh |
-      | Jonkvrouw                | Partner na eigen      | Huwelijk         | Ja                                             | T. van Hoogh-in het Veld |
+      | adellijkeTitel_predikaat | aanduidingNaamgebruik | aanschrijfwijze                    |
+      | Jonkheer                 | Eigen                 | jonkheer T. van Hoogh              |
+      | Jonkvrouw                | Eigen                 | jonkvrouw T. van Hoogh             |
+      | Jonkvrouw                | Partner na eigen      | jonkvrouw T. van Hoogh-in het Veld |
+      | Jonkvrouw                | Partner               | T. in het Veld                     |
+      | Jonkheer                 | Partner               | T. in het Veld                     |
+      | Jonkvrouw                | Partner voor eigen    | T. in het Veld-jonkvrouw van Hoogh |
+      | Jonkheer                 | Partner na eigen      | jonkheer T. van Hoogh-in het Veld  |
 
     Voorbeelden: partner heeft een adellijke titel
       | geslachtsaanduiding | geslachtsaanduiding partner | adellijkeTitel_predikaat partner | aanduidingAanschrijving | samenstelling aanschrijfwijze | geslachtsnaam | voornamen | aanschrijfwijze |
-      | V | M | Baron  | E | VL VV GN          | Veen  | Anna Cornelia  | A.C. van der Veen |
+      | V | M | Baron  | E | VL VV GN          | Veen  | Anna Cornelia  | A.C. van der Veen                       |
       | V | M | Baron  | N | VL VV GN-AP VP GP | Veen  | Anna Cornelia  | A.C. van der Veen-barones van den Aedel |
-      | V | M | Baron  | P | VL AP VP GP       | Veen  | Anna Cornelia  | A.C. barones van den Aedel |
+      | V | M | Baron  | P | VL AP VP GP       | Veen  | Anna Cornelia  | A.C. barones van den Aedel              |
       | V | M | Baron  | V | VL AP VP GP-VV GN | Veen  | Anna Cornelia  | A.C. barones van den Aedel-van der Veen |
-      | M | V | Gravin | E | VL VV GN          | Veen  | Johannes       | J. van der Veen |
-      | M | V | Gravin | N | VL VV GN-AP VP GP | Veen  | Johannes       | J. van der Veen-graaf van den Aedel |
-      | M | V | Gravin | P | VL AP VP GP       | Veen  | Johannes       | J. graaf van den Aedel |
-      | M | V | Gravin | V | VL AP VP GP-VV GN | Veen  | Johannes       | J. graaf van den Aedel-van der Veen |
-      | V | M | Ridder | E | VL VV GN          | Veen  | Marlies        | M. van der Veen |
-      | V | M | Ridder | N | VL VV GN-VP GP    | Veen  | Marlies        | M. van der Veen-van den Aedel |
-      | V | M | Ridder | P | VL VP GP          | Veen  | Marlies        | M. van den Aedel |
-      | V | M | Ridder | V | VL VP GP-VV GN    | Veen  | Marlies        | M. van den Aedel-van der Veen |
-      | V | V | Gravin | E | VL VV GN          | Veen  | Sarah          | S. van der Veen |
-      | V | V | Gravin | N | VL VV GN-VP GP    | Veen  | Sarah          | S. van der Veen-van den Aedel |
-      | V | V | Gravin | P | VL VP GP          | Veen  | Sarah          | S. van den Aedel |
-      | V | V | Gravin | V | VL VP GP-VV GN    | Veen  | Sarah          | S. van den Aedel-van der Veen |
+      | V | M | Prins  | E | VL VV GN          | Veen  | Anna Cornelia  | A.C. van der Veen                       |
+      | V | M | Prins  | N | VL VV GN-AP VP GP | Veen  | Anna Cornelia  | A.C. van der Veen-prinses van den Aedel |
+      | V | M | Prins  | P | VL AP VP GP       | Veen  | Anna Cornelia  | A.C. prinses van den Aedel              |
+      | V | M | Prins  | V | VL AP VP GP-VV GN | Veen  | Anna Cornelia  | A.C. prinses van den Aedel-van der Veen |
+      | M | V | Gravin | E | VL VV GN          | Veen  | Johannes       | J. van der Veen                         |
+      | M | V | Gravin | N | VL VV GN-VP GP    | Veen  | Johannes       | J. van der Veen-van den Aedel           |
+      | M | V | Gravin | P | VL VP GP          | Veen  | Johannes       | J. van den Aedel                        |
+      | M | V | Gravin | V | VL VP GP-VV GN    | Veen  | Johannes       | J. van den Aedel-van der Veen           |
+      | V | M | Ridder | E | VL VV GN          | Veen  | Marlies        | M. van der Veen                         |
+      | V | M | Ridder | N | VL VV GN-VP GP    | Veen  | Marlies        | M. van der Veen-van den Aedel           |
+      | V | M | Ridder | P | VL VP GP          | Veen  | Marlies        | M. van den Aedel                        |
+      | V | M | Ridder | V | VL VP GP-VV GN    | Veen  | Marlies        | M. van den Aedel-van der Veen           |
+      | V | V | Gravin | E | VL VV GN          | Veen  | Sarah          | S. van der Veen                         |
+      | V | V | Gravin | N | VL VV GN-VP GP    | Veen  | Sarah          | S. van der Veen-van den Aedel           |
+      | V | V | Gravin | P | VL VP GP          | Veen  | Sarah          | S. van den Aedel                        |
+      | V | V | Gravin | V | VL VP GP-VV GN    | Veen  | Sarah          | S. van den Aedel-van der Veen           |
+      | M | M | Baron  | E | VL VV GN          | Veen  | Willem         | W. van der Veen                         |
+      | M | M | Baron  | N | VL VV GN-VP GP    | Veen  | Willem         | W. van der Veen-van den Aedel           |
+      | M | M | Baron  | P | VL VP GP          | Veen  | Willem         | W. van den Aedel                        |
+      | M | M | Baron  | V | VL VP GP-VV GN    | Veen  | Willem         | W. van den Aedel-van der Veen           |
 
     Voorbeelden: partner heeft een predikaat
       | aanduidingAanschrijving | samenstelling aanschrijfwijze | geslachtsnaam | voornamen | aanschrijfwijze |

--- a/features/gebruik_in_lopende_tekst.feature
+++ b/features/gebruik_in_lopende_tekst.feature
@@ -22,7 +22,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
   Als de eerste naam geen adellijke titel of predicaat heeft,
   Dan wordt gebruikInLopendeTekst voorafgegaan door een geslachtsaanduiding ("mevrouw", "de heer") plus de samengestelde naam op basis van aanduidingNaamgebruik en de naam van de persoon en de partner.
 
-  Het voorvoegsel van de eerste geslachtsnaam in de samengestelde naam wordt met een hoofdletter geschreven. Het voorvoegsel van de tweede geslachtsnaam wordt met een kleine letter geschreven.
+  Het voorvoegsel van de eerste geslachtsnaam in de samengestelde naam wordt met een hoofdletter geschreven.
 
   Als er meerdere actuele (niet ontbonden) huwelijken/partnerschappen zijn
   En de aanduiding aanschijving is ongelijk aan 'Eigen',
@@ -31,20 +31,19 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
   Als er meerdere ontbonden huwelijken/partnerschappen zijn
   En er geen actueel (niet ontbonden) huwelijk/partnerschap is
   En de aanduiding aanschijving is ongelijk aan 'Eigen'
-  Dan wordt als partnernaam de naam van de laatst ontbinden relatie gebruikt.
+  Dan wordt als partnernaam de naam van de laatst ontbonden relatie gebruikt.
 
-  Op basis van attribuut adellijkeTitel_predikaat wordt het de adelijke titel of het predikaat toegevoegd in gebruikInLopendeTekst.
+  Op basis van attribuut adellijkeTitel_predikaat wordt de adelijke titel of het predikaat toegevoegd in gebruikInLopendeTekst.
   Als de betrokkene beschikt over een adellijke titel of predikaat
   Dan wordt deze geplaatst vóór het voorvoegsel van de eigen geslachtsnaam.
   Als de betrokkene beschikt over een adellijke titel of predikaat
   Dan wordt deze opgenomen zoals genoemd in kolom "Omschrijving" in GBA tabel 38 "Adellijke titel/predikaat", geschreven in kleine letters.
-  Als betrokkene beschikt over een adellijke titel
+  Als betrokkene beschikt over een adellijke titel of predicaat
   En betrokkene gebruikt de achternaam van de echtgenoot/partner in combinatie met de eigen geslachtsnaam
-  Dan wordt de titel van betrokkene voor de eigen geslachtsnaam geplaatst.
-  Als betrokkene een predikaat heeft (jonkvrouw of jonkheer)
-  En betrokkene is getrouwd of geregistreerd partnerschap of is getrouwd geweest of heeft geregistreerd partnerschap gehad
-  Dan wordt het predikaat niet gebruikt
-  En de persoon wordt dan aangesproken met "mevrouw” of “de heer” gevolgd door de samengestelde naam
+  Dan wordt de titel dan wel het predicaat van betrokkene voor de eigen geslachtsnaam geplaatst.
+  Als betrokkene een adellijke titel of predicaat heeft
+  En betrokkene gebruikt alleen de naam van de partner (aanduiding naamgebruik is "P")
+  Dan wordt de eigen adellijke titel of het predicaat niet gebruikt.
 
   Als een vrouw als partner of echtgenoot een man met adellijke titel heeft,
   En deze adellijke titel heeft een vrouwelijke vorm (zie tabel hieronder),
@@ -54,14 +53,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
   | Baron	| barones          |
   | Prins	| prinses          |
 
-  Als een man als partner of echtgenote een vrouw met adellijke titel heeft,
-  Dan wordt die adellijke titel in mannelijke vorm opgenomen wanneer hij de naam van zijn partner gebruikt.
-  | Titel   | Mannelijke vorm |
-  | Gravin	| graaf           |
-  | Barones	| baron           |
-  | Prinses	| prins           |
-
-  Als betrokkene en partner hetzelfde geslacht hebben Of de titel van de partner komt niet voor in bovenstaande tabellen (er is geen vrouwelijke vorm van de titel),
+  Als betrokkene en partner hetzelfde geslacht hebben Of de titel van de partner komt niet voor in bovenstaande tabel (er is geen vrouwelijke vorm van de titel),
   Dan wordt de adellijke titel van de partner niet opgenomen.
 
   Abstract Scenario: gebruikInLopendeTekst wordt samengesteld op basis van geslachtsaanduiding en naamgegevens van de persoon en de partner
@@ -90,26 +82,24 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
       | Partner voor eigen    | Man                 | GA VP GP-VV GN  | F. Groenen-Groenink       | de heer Groenen-Groenink       |
 
     Voorbeelden: adelijke titels
-      | adellijkeTitel_predikaat | aanduidingNaamgebruik | geslachtsaanduiding | samenstelling gebruikInLopendeTekst | aanschrijfwijze              | gebruikInLopendeTekst                        |
-      | Baron                    | Eigen                 | Man                 | AT VV GN             | H.W. baron Van den Aedel                    | baron Van den Aedel                          |
-      | Barones                  | Partner na eigen      | Vrouw               | AT VV GN-VP GP       | W. barones van den Aedel-van der Veen       | barones Van den Aedel-van der Veen           |
-      | Graaf                    | Partner               | Man                 | GA VP GP             | F. van der Veen                             | de heer Van der Veen                         |
-      | Gravin                   | Partner voor eigen    | Vrouw               | GA VP GP-AT VV GN    | E.L. van der Veen-gravin van den Aedel      | mevrouw Van der Veen-gravin van den Aedel    |
-      | Prins                    | Eigen                 | Man                 | AT VV GN             | O.B.B. prins van Roodt de Wit Blaauw        | prins Van Roodt de Wit Blaauw                |
-      | Prinses                  | Eigen                 | Vrouw               | AT VV GN             | E.M.V. prinses van Roodt de Wit Blaauw      | prinses Van Roodt de Wit Blaauw              |
-      | Ridder                   | Eigen                 | Man                 | T VV GN              | M. ridder van Hoogh                         | ridder Van Hoogh                             |
+      | adellijkeTitel_predikaat | aanduidingNaamgebruik | geslachtsaanduiding | samenstelling gebruikInLopendeTekst | gebruikInLopendeTekst                        |
+      | Baron                    | Eigen                 | Man                 | AT VV GN                            | baron Van den Aedel                          |
+      | Barones                  | Partner na eigen      | Vrouw               | AT VV GN-VP GP                      | barones Van den Aedel-van der Veen           |
+      | Graaf                    | Partner               | Man                 | GA VP GP                            | de heer Van der Veen                         |
+      | Gravin                   | Partner voor eigen    | Vrouw               | GA VP GP-AT VV GN                   | mevrouw Van der Veen-gravin van den Aedel    |
+      | Prins                    | Eigen                 | Man                 | AT VV GN                            | prins Van Roodt de Wit Blaauw                |
+      | Prinses                  | Eigen                 | Vrouw               | AT VV GN                            | prinses Van Roodt de Wit Blaauw              |
+      | Ridder                   | Eigen                 | Man                 | T VV GN                             | ridder Van Hoogh                             |
 
     Voorbeelden: predikaat
-      | adellijkeTitel_predikaat | aanduidingNaamgebruik | soortVerbintenis | Ontbinding huwelijk/geregistreerd partnerschap | aanhef                        |
-      | Jonkheer                 | Eigen                 | Geen             | Geen                                           | jonkheer Van Hoogh            |
-      | Jonkvrouw                | Eigen                 | Geen             | Geen                                           | jonkvrouw Van Hoogh           |
-      | Jonkheer                 | Eigen                 | Huwelijk         | Niet                                           | de heer Van Hoogh             |
-      | Jonkheer                 | Eigen                 | Partnerschap     | Niet                                           | de heer Van Hoogh             |
-      | Jonkheer                 | Eigen                 | Huwelijk         | Ja                                             | de heer Van Hoogh             |
-      | Jonkvrouw                | Eigen                 | Huwelijk         | Niet                                           | mevrouw Van Hoogh             |
-      | Jonkvrouw                | Partner na eigen      | Huwelijk         | Niet                                           | mevrouw Van Hoogh-in het Veld |
-      | Jonkvrouw                | Partner               | Huwelijk         | Niet                                           | mevrouw In het Veld           |
-      | Jonkvrouw                | Partner voor eigen    | Huwelijk         | Niet                                           | mevrouw In het Veld-van Hoogh |
+      | adellijkeTitel_predikaat | aanduidingNaamgebruik | partner | aanhef                                  |
+      | Jonkheer                 | Eigen                 | Geen    | jonkheer Van Hoogh                      |
+      | Jonkvrouw                | Eigen                 | Geen    | jonkvrouw Van Hoogh                     |
+      | Jonkheer                 | Eigen                 | Ja      | jonkheer Van Hoogh                      |
+      | Jonkvrouw                | Eigen                 | Ja      | jonkvrouw Van Hoogh                     |
+      | Jonkvrouw                | Partner na eigen      | Ja      | jonkvrouw Van Hoogh-in het Veld         |
+      | Jonkvrouw                | Partner               | Ja      | mevrouw In het Veld                     |
+      | Jonkvrouw                | Partner voor eigen    | Ja      | mevrouw In het Veld-jonkvrouw van Hoogh |
 
     Voorbeelden: partner heeft adelijke titel of predikaat
       | geslachtsaanduiding | geslachtsaanduiding partner | adellijkeTitel_predikaat partner | aanduidingNaamgebruik | aanschrijfwijze | gebruikInLopendeTekst |
@@ -118,15 +108,16 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
       | V | M | Baron    | Partner               | A.C. barones van den Aedel              | barones Van den Aedel                      |
       | V | M | Baron    | Partner voor eigen    | A.C. barones van den Aedel-van der Veen | barones Van den Aedel-van der Veen         |
       | M | V | Gravin   | Eigen                 | W. van der Veen                         | de heer Van der Veen                       |
-      | M | V | Gravin   | Partner na eigen      | W. van der Veen-graaf van den Aedel     | de heer Van der Veen-graaf van den Aedel   |
-      | M | V | Gravin   | Partner               | W. graaf van den Aedel                  | graaf Van den Aedel                        |
-      | M | V | Gravin   | Partner voor eigen    | W. graaf van den Aedel-van der Veen     | graaf Van den Aedel-van der Veen           |
+      | M | V | Gravin   | Partner na eigen      | W. van der Veen-graaf van den Aedel     | de heer Van der Veen-van den Aedel         |
+      | M | V | Gravin   | Partner               | W. graaf van den Aedel                  | de heer Van den Aedel                      |
+      | M | V | Gravin   | Partner voor eigen    | W. graaf van den Aedel-van der Veen     | de heer Van den Aedel-van der Veen         |
       | M | M | Baron    | Partner na eigen      | W. van der Veen-van den Aedel           | de heer Van der Veen-van den Aedel         |
+      | V | V | Barones  | Partner na eigen      | W. van der Veen-van den Aedel           | mevrouw Van der Veen-van den Aedel         |
       | V | M | Ridder   | Partner na eigen      | W. van der Veen-van den Aedel           | mevrouw Van der Veen-van den Aedel         |
       | V | M | Jonkheer | Eigen                 | A.C. van der Veen                       | mevrouw Van der Veen                       |
-      | V | M | Jonkheer | Partner na eigen      | A.C. van der Veen-van den Aedel         | mevrouw van der Veen-van den Aedel         |
-      | V | M | Jonkheer | Partner               | A.C. van den Aedel                      | mevrouw van den Aedel                      |
-      | V | M | Jonkheer | Partner voor eigen    | A.C. van den Aedel-van der Veen         | mevrouw van den Aedel-van der Veen         |
+      | V | M | Jonkheer | Partner na eigen      | A.C. van der Veen-van den Aedel         | mevrouw Van der Veen-van den Aedel         |
+      | V | M | Jonkheer | Partner               | A.C. van den Aedel                      | mevrouw Van den Aedel                      |
+      | V | M | Jonkheer | Partner voor eigen    | A.C. van den Aedel-van der Veen         | mevrouw Van den Aedel-van der Veen         |
 
   Scenario: meerdere actuele relaties
     Gegeven de ingeschreven persoon de heer F.C. Groen is getrouwd in 1958 met Geel


### PR DESCRIPTION
verschillende wijzigingen aan features voor aanhef, aanschrijfwijze en gebruikInLopendeTest met betrekking tot gebruik van adellijke titels en predicaten.
Dit betreft:
- wel predicaat gebruiken wanneer men getrouwd is (geweest)
- wanneer een jonkvrouw getrouwd is of partnerschap heeft, wordt in de aanhef niet hoogwelgeboren vrouwe gebruikt, wanneer het huwelijk of partnerschap wordt ontbonden (en ze de naam van haar ex-partner niet gebruikt) wordt ze wel weer aangesproken met hoogwelgeboren vrouw
- een man mag niet de adellijke titel van zijn vrouw gebruiken