### PR TITLE
allOf verwijderd uit de gemeente_links vanwege code-generaties issues.

### DIFF
--- a/api-specificatie/Landelijke tabellen/openapi.yaml
+++ b/api-specificatie/Landelijke tabellen/openapi.yaml
@@ -827,10 +827,7 @@ components:
         self:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/common.yaml#/components/schemas/HalLink"
         overgegaanIn:
-          allOf: 
-            - title: "overgegaanIn"
-              description: "De gemeente waarin deze gemeente is overgegaan bij een gemeentelijke herindeling. "
-            - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Nationaliteit:
       allOf: 
         - $ref: "#/components/schemas/Landelijke_Tabel"

--- a/api-specificatie/Landelijke tabellen/resolved/openapi.yaml
+++ b/api-specificatie/Landelijke tabellen/resolved/openapi.yaml
@@ -54,7 +54,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -71,7 +71,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/NationaliteitenHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -94,7 +94,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -113,7 +113,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -131,7 +131,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -150,7 +150,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -168,7 +168,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -186,7 +186,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -205,7 +205,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -222,7 +222,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -240,7 +240,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -258,7 +258,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -302,7 +302,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -319,7 +319,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Nationaliteit'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -342,7 +342,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -361,7 +361,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -379,7 +379,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -396,7 +396,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -415,7 +415,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -433,7 +433,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -451,7 +451,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -470,7 +470,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -487,7 +487,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -505,7 +505,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -523,7 +523,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -591,7 +591,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -608,7 +608,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/GemeenteHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -631,7 +631,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -650,7 +650,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -668,7 +668,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -687,7 +687,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -705,7 +705,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -723,7 +723,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -742,7 +742,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -759,7 +759,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -777,7 +777,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -795,7 +795,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -839,7 +839,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -856,7 +856,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/GemeenteHal'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -879,7 +879,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -898,7 +898,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -916,7 +916,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -933,7 +933,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -952,7 +952,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -970,7 +970,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -988,7 +988,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -1007,7 +1007,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -1024,7 +1024,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -1042,7 +1042,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -1060,7 +1060,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -1128,7 +1128,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -1145,7 +1145,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/LandHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -1168,7 +1168,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -1187,7 +1187,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -1205,7 +1205,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -1224,7 +1224,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -1242,7 +1242,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -1260,7 +1260,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -1279,7 +1279,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -1296,7 +1296,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -1314,7 +1314,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -1332,7 +1332,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -1376,7 +1376,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -1393,7 +1393,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Land'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -1416,7 +1416,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -1435,7 +1435,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -1453,7 +1453,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -1470,7 +1470,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -1489,7 +1489,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -1507,7 +1507,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -1525,7 +1525,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -1544,7 +1544,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -1561,7 +1561,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -1579,7 +1579,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -1597,7 +1597,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -1665,7 +1665,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -1682,7 +1682,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/RedenNationaliteitHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -1705,7 +1705,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -1724,7 +1724,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -1742,7 +1742,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -1761,7 +1761,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -1779,7 +1779,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -1797,7 +1797,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -1816,7 +1816,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -1833,7 +1833,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -1851,7 +1851,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -1869,7 +1869,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -1913,7 +1913,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -1930,7 +1930,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/RedenNationaliteit'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -1953,7 +1953,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -1972,7 +1972,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -1990,7 +1990,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -2007,7 +2007,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -2026,7 +2026,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -2044,7 +2044,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -2062,7 +2062,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -2081,7 +2081,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -2098,7 +2098,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -2116,7 +2116,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -2134,7 +2134,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -2202,7 +2202,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -2219,7 +2219,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/RedenBeeindigenHuwelijkHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -2242,7 +2242,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -2261,7 +2261,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -2279,7 +2279,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -2298,7 +2298,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -2316,7 +2316,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -2334,7 +2334,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -2353,7 +2353,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -2370,7 +2370,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -2388,7 +2388,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -2406,7 +2406,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -2450,7 +2450,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -2467,7 +2467,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/RedenBeeindigenHuwelijk'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -2490,7 +2490,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -2509,7 +2509,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -2527,7 +2527,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -2544,7 +2544,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -2563,7 +2563,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -2581,7 +2581,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -2599,7 +2599,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -2618,7 +2618,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -2635,7 +2635,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -2653,7 +2653,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -2671,7 +2671,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -2739,7 +2739,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -2756,7 +2756,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/NederlandsReisdocumentHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -2779,7 +2779,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -2798,7 +2798,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -2816,7 +2816,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -2835,7 +2835,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -2853,7 +2853,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -2871,7 +2871,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -2890,7 +2890,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -2907,7 +2907,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -2925,7 +2925,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -2943,7 +2943,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -2987,7 +2987,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -3004,7 +3004,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/NederlandsReisdocument'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -3027,7 +3027,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -3046,7 +3046,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -3064,7 +3064,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -3081,7 +3081,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -3100,7 +3100,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -3118,7 +3118,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -3136,7 +3136,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -3155,7 +3155,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -3172,7 +3172,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -3190,7 +3190,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -3208,7 +3208,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -3276,7 +3276,7 @@ paths:
         schema:
           type: boolean
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -3293,7 +3293,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/VerblijfstitelHalCollectie'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -3316,7 +3316,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -3335,7 +3335,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -3353,7 +3353,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -3372,7 +3372,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -3390,7 +3390,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -3408,7 +3408,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -3427,7 +3427,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -3444,7 +3444,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -3462,7 +3462,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -3480,7 +3480,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -3524,7 +3524,7 @@ paths:
         schema:
           type: string
       responses:
-        200:
+        "200":
           description: Zoekactie geslaagd
           headers:
             api-version:
@@ -3541,7 +3541,7 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Verblijfstitel'
-        400:
+        "400":
           description: Bad Request
           headers:
             api-version:
@@ -3564,7 +3564,7 @@ paths:
                   name: verblijfplaats__huisnummer
                   code: integer
                   reason: Waarde is geen geldige integer.
-        401:
+        "401":
           description: Unauthorized
           headers:
             api-version:
@@ -3583,7 +3583,7 @@ paths:
                   a challenge applicable to the requested resource.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: authentication
-        403:
+        "403":
           description: Forbidden
           headers:
             api-version:
@@ -3601,7 +3601,7 @@ paths:
                   it.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: autorisation
-        404:
+        "404":
           description: Not Found
           headers:
             api-version:
@@ -3618,7 +3618,7 @@ paths:
                 detail: The server has not found anything matching the Request-URI.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notFound
-        406:
+        "406":
           description: Not Acceptable
           headers:
             api-version:
@@ -3637,7 +3637,7 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        409:
+        "409":
           description: Conflict
           headers:
             api-version:
@@ -3655,7 +3655,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: conflict
-        410:
+        "410":
           description: Gone
           headers:
             api-version:
@@ -3673,7 +3673,7 @@ paths:
                   the current state of the resource
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: gone
-        415:
+        "415":
           description: Unsupported Media Type
           headers:
             api-version:
@@ -3692,7 +3692,7 @@ paths:
                   the requested method.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: unsupported
-        429:
+        "429":
           description: Too Many Requests
           headers:
             api-version:
@@ -3709,7 +3709,7 @@ paths:
                   (rate limiting).
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: tooManyRequests
-        500:
+        "500":
           description: Internal Server Error
           headers:
             api-version:
@@ -3727,7 +3727,7 @@ paths:
                   it from fulfilling the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: serverError
-        501:
+        "501":
           description: Not Implemented
           headers:
             api-version:
@@ -3745,7 +3745,7 @@ paths:
                   fulfill the request.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notImplemented
-        503:
+        "503":
           description: Service Unavailable
           headers:
             api-version:
@@ -3822,11 +3822,7 @@ components:
         self:
           $ref: '#/components/schemas/HalLink'
         overgegaanIn:
-          allOf:
-          - title: overgegaanIn
-            description: 'De gemeente waarin deze gemeente is overgegaan bij een gemeentelijke
-              herindeling. '
-          - $ref: '#/components/schemas/HalLink'
+          $ref: '#/components/schemas/HalLink'
     Nationaliteit:
       allOf:
       - $ref: '#/components/schemas/Landelijke_Tabel'


### PR DESCRIPTION
Blijkbaar is de resolver aangepast en worden er nu quotes om de https-foutcodes gezet. In de geresolvde versie dus meer aanpassingen die geen impact op de werking zouden mogen hebben. 