### PR TITLE
link type en invalid-params

### DIFF
--- a/api-specificatie/common.yaml
+++ b/api-specificatie/common.yaml
@@ -311,15 +311,14 @@ components:
     HalLink:
       description: De Link Object zoals gespecificeerd in https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
       type: object
-      required: 
+      required:
         - href
       properties:
         href:
           $ref: "#/components/schemas/Href"
-        type:
-         description: "Met dit element wordt aangegeven in welk domein de resource te vinden is waarnaar deze link verwijst. Voorbeelden daarvan zijn *BAG*, *BRP*, *BRK*, *HR*. "
+        title:
+         description: "Voor mens leesbaar label bij de link"
          type: string
-         example: "BAG"   
     HalCollectionLinks:
       type: object
       properties:
@@ -414,7 +413,7 @@ components:
       - $ref: '#/components/schemas/Foutbericht'
       - type: object
         properties:
-          invalid-params:
+          invalidParams:
             description: Foutmelding per fout in een parameter. Alle gevonden fouten worden één keer teruggemeld.
             type: array
             items:


### PR DESCRIPTION
#543 hal link type vervangen door title,
invalid-params is invalidParams geworden, n.a.v. [API-standaard wijziging](https://github.com/Geonovum/KP-APIs/pull/191)