### PR TITLE
feature voor nationaliteit

### DIFF
--- a/features/actuele_ingeschreven_persoon.feature
+++ b/features/actuele_ingeschreven_persoon.feature
@@ -1,20 +1,20 @@
 # language: nl
 
 Functionaliteit: Voor ingeschreven_personen worden alleen actuele gegevens getoond
-  
-  Voor diverse groepen gegevens is het mogelijk dat de gegevens die voor een persoon geregistreerd zijn een einddatum kennen. 
-  Als bij een dergelijke groep de einddatum daadwerkelijk is ingevuld en in het verleden ligt, dan worden deze gegevens niet getoond. 
-  Voorbeelden van deze groepen gegevens zijn : Nationaliteit, Verblijfstitel, Huwelijk/geregistreerd partnerschap, Verblijfplaats, Kiesrecht. 
-  
-  Voor Huwelijk/geregistreerd partnerschap beschrijft de [partners feature](./partners.feature) de exacte functionaliteit. 
+
+  Voor diverse groepen gegevens is het mogelijk dat de gegevens die voor een persoon geregistreerd zijn een einddatum kennen.
+  Als bij een dergelijke groep de einddatum daadwerkelijk is ingevuld en in het verleden ligt, dan worden deze gegevens niet getoond.
+  Voorbeelden van deze groepen gegevens zijn : Nationaliteit, Verblijfstitel, Huwelijk/geregistreerd partnerschap, Verblijfplaats, Kiesrecht.
+
+  Voor Huwelijk/geregistreerd partnerschap beschrijft de [partners feature](./partners.feature) de exacte functionaliteit.
   Voor kiesrecht beschrijft de [kiesrecht feature](./kiesrecht.feature) de exacte functionaliteit.
-  
-  Alleen gegevens uit de actuele LO GBA categorieën worden opgenomen (Categorieën 01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 12, 13) 
-  
+  Voor nationaliteit beschrijft de [nationaliteit feature](./nationaliteit.feature) de exacte functionaliteit.
+
+  Alleen gegevens uit de actuele LO GBA categorieën worden opgenomen (Categorieën 01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 12, 13)
+
 
   Scenario: de ingeschreven persoon heeft een beëindigde verblijfstitel
     Gegeven de te raadplegen persoon heeft een verblijfstitel waarvan de einddatum in het verleden ligt
     En de te raadplegen persoon heeft geen andere of nieuwe verblijfstitel
     Als de ingeschreven persoon met burgerservicenummer 999999321 wordt geraadpleegd
     Dan is de verblijfstitel van de betreffende ingeschreven persoon leeg
-

--- a/features/nationaliteit.feature
+++ b/features/nationaliteit.feature
@@ -1,0 +1,59 @@
+# language: nl
+
+Functionaliteit: Bepalen van de actuele nationaliteit van een ingeschreven persoon
+  Niet-beëindigde nationaliteiten van de ingeschreven persoon wordt opgenomen.
+
+  In het antwoord voor ingeschrevenpersonen worden alleen nationaliteiten opgenomen waarbij in categorie 04 nationaliteit (05.10) of aanduiding bijzonder Nederlanderschap (65.10) is opgenomen, en in categorie 04 GEEN reden beëindigen nationaliteit (64.10) is opgenomen.
+
+  Voor een nationaliteit wordt de datumIngangGeldigheid gevuld met de datum geldigheid (85.10) uit de oudste bijbehorende categorie (04 of 54) waarin er een waarde is voor 05.10 of voor 65.10.
+  De overige gegevens over een nationaliteit worden gehaald uit categorie 04.
+
+  Een onjuiste nationaliteit wordt niet opgenomen. Een nationaliteit waarbij indicatie onjuist (84.10) is gevuld, wordt niet opgenomen in het antwoord.
+  Voor een actuele nationaliteit met een bijbehorende historische categorie 54 met indicatie onjuist, worden de gegevens in de onjuiste categorie (incl. datum ingang) genegeerd.
+
+  Gegeven de ingeschreven persoon met burgerservicenummer 999995555 kent de volgende nationaliteiten:
+     | Stapel | Categorie | 05.10 | 63.10 | 64.10 | 85.10    |
+     | 1      | 04        | 0001  | 018   |       | 20180731 |
+     | 1      | 04        | 0001  | 057   |       | 20160803 |
+     | 2      | 54        |       |       | 403   | 20170526 |
+     | 2      | 54        |       |       | 402   | 20170210 |
+     | 2      | 54        | 0449  | 301   |       | 19930419 |
+
+  En de ingeschreven persoon met burgerservicenummer 999992466 kent de volgende nationaliteiten:
+    | Stapel | Categorie | 05.10 | 63.10 | 64.10 | 85.10    | 84.10 |
+    | 1      | 04        | 0057  | 301   |       | 20160601 |       |
+    | 1      | 54        | 0057  | 301   |       | 20160501 |       |
+    | 1      | 54        | 0057  | 301   |       | 20160401 |       |
+    | 1      | 54        | 0057  | 301   |       | 20160301 | O     |
+
+  En de ingeschreven persoon met burgerservicenummer 999992855 kent de volgende nationaliteiten:
+    | Stapel | Categorie | 05.10 | 63.10 | 64.10 | 85.10    | 84.10 |
+    | 1      | 04        | 0001  | 018   |       | 20041015 |       |
+    | 2      | 04        |       |       |       | 20121022 |       |
+    | 2      | 54        | 0251  |       |       | 20121022 | O     |
+    | 3      | 04        | 0445  |       |       | 19611230 |       |
+    | 4      | 04        | 0446  |       |       | 19611230 |       |
+
+  Scenario: ingangsdatum en einddatum bij gewijzigde nationaliteitsgegevens
+    Als de nationaliteithistorie met burgerservicenummer 9999955555 wordt geraadpleegd
+    Dan bevat het antwoord 1 voorkomens van nationaliteit
+    En worden de volgende nationaliteiten teruggegeven:
+      | # | nationaliteit.code | datumIngangGeldigheid | redenOpname.code |
+      | 0 | 0001               | 2016-08-03            | 018              |
+
+  Scenario: Historische nationaliteit is onjuist maar actuele is juist
+    Als de nationaliteithistorie met burgerservicenummer 999992466 wordt geraadpleegd
+    Dan bevat het antwoord 1 voorkomens
+    En worden de nationaliteiten teruggegeven in de volgorde en met waarden:
+      | # | nationaliteit.code | datumIngangGeldigheid | datumEindeGeldigheid | redenOpname.code | redenBeeindigen.code |
+      | 0 | 0057               | 2016-04-01            | -                    | 301              | -                    |
+
+  Scenario: Nationaliteit is onjuist
+    Als de nationaliteithistorie met burgerservicenummer 999992466 wordt geraadpleegd
+    Dan bevat het antwoord 3 voorkomens
+    En bevat het antwoord geen nationaliteit.code 0251
+    En worden de nationaliteiten teruggegeven in de volgorde en met waarden:
+     | # | nationaliteit.code | datumIngangGeldigheid | datumEindeGeldigheid | redenOpname.code | redenBeeindigen.code |
+     | 0 | 0001               | 2004-10-15            | -                    | 018              | -                    |
+     | 1 | 0445               | 1961-12-30            | -                    | -                | -                    |
+     | 2 | 0446               | 1961-12-30            | -                    | -                | -                    |


### PR DESCRIPTION
nieuwe feature voor bepalen van de actuele nationaliteit:
- alleen niet-beëindigde nationaliteiten
- haal datumIngangGeldigheid uit de eerste bijbehorende categorie
- geen onjuiste nationaliteiten opnemen