### PR TITLE
parameter burgerservicenummer explode en voorbeeld

### DIFF
--- a/api-specificatie/Bevraging-Ingeschreven-Persoon/openapi.yaml
+++ b/api-specificatie/Bevraging-Ingeschreven-Persoon/openapi.yaml
@@ -68,6 +68,8 @@ paths:
             \ dat, indien aangeduid als (s0 s1 s2 s3 s4 s5 s6 s7 s8), het resultaat\
             \ van (9*s0) + (8*s1) + (7*s2) +...+ (2*s7) - (1*s8) deelbaar is door\
             \ elf. Er moeten dus 9 cijfers aanwezig zijn."
+          explode: false
+          example: 999993653,999991723,999995078
           schema:
             type: array
             items:


### PR DESCRIPTION
query parameter burgerservicenummer is gedefinieerd als array, gewijzigd explode=false en bijbehorend voorbeeld, zodat bij meerdere burgerservicenummers niet elke keer de parameternaam hoeft te worden opgenomen. Dus ?burgerservicenummer=999993653,999991723,999995078 i.p.v. ?burgerservicenummer=999993653&burgerservicenummer=999991723&burgerservicenummer=999995078