### PR TITLE
verblijfplaatsnummeraanduiding verwijderd bij ingeschrevenPersoon

### DIFF
--- a/api-specificatie/Bevraging-Ingeschreven-Persoon/openapi.yaml
+++ b/api-specificatie/Bevraging-Ingeschreven-Persoon/openapi.yaml
@@ -908,8 +908,6 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/Reisdocumentnummer"
-        verblijfplaatsnummeraanduiding:
-            type: string
     IngeschrevenPersoonHalCollectie:
       type: object
       properties:


### PR DESCRIPTION
Deze is toegevoegd omdat we van gerelateerde resources (links) ook de identificatie(s) zouden opnemen in de bevraagde resource. Echter de identificatiecodeNummeraanduiding is al opgenomen in de gegevensgroep "verblijfplaats" van de ingeschrevenPersoon