### PR TITLE
verwijderen x-rate-limit headers en overbodige responses

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -227,15 +227,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -340,98 +331,6 @@
                   "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
                   "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
                   "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
                 }
               }
             }
@@ -563,15 +462,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -703,98 +593,6 @@
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
           "500" : {
             "description" : "Internal Server Error",
             "headers" : {
@@ -916,15 +714,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -1056,98 +845,6 @@
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
           "500" : {
             "description" : "Internal Server Error",
             "headers" : {
@@ -1259,15 +956,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -1399,98 +1087,6 @@
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
           "500" : {
             "description" : "Internal Server Error",
             "headers" : {
@@ -1612,15 +1208,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -1752,98 +1339,6 @@
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
           "500" : {
             "description" : "Internal Server Error",
             "headers" : {
@@ -1955,15 +1450,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -2095,98 +1581,6 @@
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
           "500" : {
             "description" : "Internal Server Error",
             "headers" : {
@@ -2308,15 +1702,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -2448,98 +1833,6 @@
               }
             }
           },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
-                }
-              }
-            }
-          },
           "500" : {
             "description" : "Internal Server Error",
             "headers" : {
@@ -2651,15 +1944,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -2787,98 +2071,6 @@
                   "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
                   "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
                   "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
                 }
               }
             }
@@ -3032,15 +2224,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -3168,98 +2351,6 @@
                   "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
                   "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
                   "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
                 }
               }
             }
@@ -3413,15 +2504,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -3549,98 +2631,6 @@
                   "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
                   "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
                   "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
                 }
               }
             }
@@ -3794,15 +2784,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -3930,98 +2911,6 @@
                   "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
                   "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
                   "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
                 }
               }
             }
@@ -4175,15 +3064,6 @@
               },
               "warning" : {
                 "$ref" : "#/components/headers/warning"
-              },
-              "X-Rate-Limit-Limit" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Limit"
-              },
-              "X-Rate-Limit-Remaining" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Remaining"
-              },
-              "X-Rate-Limit-Reset" : {
-                "$ref" : "#/components/headers/X_Rate_Limit_Reset"
               }
             },
             "content" : {
@@ -4311,98 +3191,6 @@
                   "detail" : "The resource identified by the request is only capable of generating response entities which have content characteristics not acceptable according to thr accept headers sent in the request",
                   "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
                   "code" : "notAcceptable"
-                }
-              }
-            }
-          },
-          "409" : {
-            "description" : "Conflict",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict",
-                  "title" : "Conflict",
-                  "status" : 409,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "conflict"
-                }
-              }
-            }
-          },
-          "410" : {
-            "description" : "Gone",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone",
-                  "title" : "Gone",
-                  "status" : 410,
-                  "detail" : "The request could not be completed due to a conflict with the current state of the resource",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "gone"
-                }
-              }
-            }
-          },
-          "415" : {
-            "description" : "Unsupported Media Type",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type",
-                  "title" : "Unsupported Media Type",
-                  "status" : 415,
-                  "detail" : "The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "unsupported"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too Many Requests",
-            "headers" : {
-              "api-version" : {
-                "$ref" : "#/components/headers/api_version"
-              }
-            },
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Foutbericht"
-                },
-                "example" : {
-                  "type" : "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                  "title" : "Too many request",
-                  "status" : 429,
-                  "detail" : "The user has sent too many requests in a given amount of time (rate limiting).",
-                  "instance" : "https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde",
-                  "code" : "tooManyRequests"
                 }
               }
             }
@@ -6140,21 +4928,6 @@
           "type" : "string",
           "description" : "zie RFC 7234. In het geval een major versie wordt uitgefaseerd, gebruiken we warn-code 299 (\"Miscellaneous Persistent Warning\") en het API end-point (inclusief versienummer) als de warn-agent van de warning, gevolgd door de warn-text met de human-readable waarschuwing",
           "example" : "299 https://service.../api/.../v1 \"Deze versie van de API is verouderd en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie hier de documentatie: https://omgevingswet.../api/.../v1\"."
-        }
-      },
-      "X_Rate_Limit_Limit" : {
-        "schema" : {
-          "type" : "integer"
-        }
-      },
-      "X_Rate_Limit_Remaining" : {
-        "schema" : {
-          "type" : "integer"
-        }
-      },
-      "X_Rate_Limit_Reset" : {
-        "schema" : {
-          "type" : "integer"
         }
       }
     }

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -278,12 +278,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -367,78 +361,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -548,12 +470,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -654,78 +570,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -820,12 +664,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -926,78 +764,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -1084,12 +850,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -1190,78 +950,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -1356,12 +1044,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -1462,78 +1144,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -1620,12 +1230,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -1726,78 +1330,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -1892,12 +1424,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -1998,78 +1524,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -2158,12 +1612,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -2264,78 +1712,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -2463,12 +1839,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -2569,78 +1939,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -2764,12 +2062,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -2870,78 +2162,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -3067,12 +2287,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -3173,78 +2387,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -3370,12 +2512,6 @@ paths:
               $ref: '#/components/headers/api_version'
             warning:
               $ref: '#/components/headers/warning'
-            X-Rate-Limit-Limit:
-              $ref: '#/components/headers/X_Rate_Limit_Limit'
-            X-Rate-Limit-Remaining:
-              $ref: '#/components/headers/X_Rate_Limit_Remaining'
-            X-Rate-Limit-Reset:
-              $ref: '#/components/headers/X_Rate_Limit_Reset'
           content:
             application/hal+json:
               schema:
@@ -3476,78 +2612,6 @@ paths:
                   not acceptable according to thr accept headers sent in the request
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAcceptable
-        "409":
-          description: Conflict
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10
-                  409 Conflict
-                title: Conflict
-                status: 409
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: conflict
-        "410":
-          description: Gone
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11
-                  410 Gone
-                title: Gone
-                status: 410
-                detail: The request could not be completed due to a conflict with
-                  the current state of the resource
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: gone
-        "415":
-          description: Unsupported Media Type
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16
-                  415 Unsupported Media Type
-                title: Unsupported Media Type
-                status: 415
-                detail: The server is refusing the request because the entity of the
-                  request is in a format not supported by the requested resource for
-                  the requested method.
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: unsupported
-        "429":
-          description: Too Many Requests
-          headers:
-            api-version:
-              $ref: '#/components/headers/api_version'
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Foutbericht'
-              example:
-                type: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
-                title: Too many request
-                status: 429
-                detail: The user has sent too many requests in a given amount of time
-                  (rate limiting).
-                instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
-                code: tooManyRequests
         "500":
           description: Internal Server Error
           headers:
@@ -5101,12 +4165,3 @@ components:
         example: '299 https://service.../api/.../v1 "Deze versie van de API is verouderd
           en zal uit dienst worden genomen op 2018-02-01. Raadpleeg voor meer informatie
           hier de documentatie: https://omgevingswet.../api/.../v1".'
-    X_Rate_Limit_Limit:
-      schema:
-        type: integer
-    X_Rate_Limit_Remaining:
-      schema:
-        type: integer
-    X_Rate_Limit_Reset:
-      schema:
-        type: integer

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -188,12 +188,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -206,14 +200,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/403"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -240,12 +226,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -260,14 +240,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -298,12 +270,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -318,14 +284,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -350,12 +308,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -370,14 +322,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -408,12 +352,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -428,14 +366,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -460,12 +390,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -480,14 +404,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/403"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -518,12 +434,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -538,14 +448,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -570,12 +472,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -590,14 +486,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -626,12 +514,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -646,14 +528,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -682,12 +556,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -702,14 +570,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -738,12 +598,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -758,14 +612,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
@@ -794,12 +640,6 @@ paths:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/warning"
-            X-Rate-Limit-Limit:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Limit"
-            X-Rate-Limit-Remaining:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Remaining"
-            X-Rate-Limit-Reset:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/headers/X_Rate_Limit_Reset"
           content:
             application/hal+json:
               schema:
@@ -814,14 +654,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/406"
-        '409':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/409"
-        '410':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/410"
-        '415':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/415"
-        '429':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/429"
         '500':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.1.0/api-specificatie/common.yaml#/components/responses/500"
         '501':

--- a/test/BRP-Bevragen-postman-collection.json
+++ b/test/BRP-Bevragen-postman-collection.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "9f1a10a4-7c10-4739-a617-b365fb0942b8",
+            "id": "7d70b5e5-d135-42a6-a696-96e21c5e527d",
             "name": "ingeschrevenpersonen",
             "item": [
                 {
-                    "id": "e624ceec-1a67-4736-b453-0a611daa2646",
+                    "id": "05659dbd-3fe0-4a53-af1d-4716c2f3da25",
                     "name": "ingeschreven Natuurlijk Personen",
                     "request": {
                         "name": "ingeschreven Natuurlijk Personen",
@@ -114,7 +114,7 @@
                     },
                     "response": [
                         {
-                            "id": "ce746527-88ec-4759-b9c1-3fffa64ad0b4",
+                            "id": "bdc9bcfa-4f25-4598-a121-e75baf570df7",
                             "name": "Zoekactie geslaagd",
                             "originalRequest": {
                                 "url": {
@@ -213,21 +213,6 @@
                                     "description": ""
                                 },
                                 {
-                                    "key": "X-Rate-Limit-Limit",
-                                    "value": "<integer>",
-                                    "description": ""
-                                },
-                                {
-                                    "key": "X-Rate-Limit-Remaining",
-                                    "value": "<integer>",
-                                    "description": ""
-                                },
-                                {
-                                    "key": "X-Rate-Limit-Reset",
-                                    "value": "<integer>",
-                                    "description": ""
-                                },
-                                {
                                     "key": "Content-Type",
                                     "value": "application/hal+json"
                                 }
@@ -237,7 +222,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "bdf73a5f-9fbf-4f52-9a6c-d405553ae2f0",
+                            "id": "d0c25d28-f4df-4835-9fcf-a5520f45ab04",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -340,7 +325,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a625835b-4725-4882-b2ab-e0e4db9b6ff8",
+                            "id": "d4f994bf-f477-471f-ae0a-ea171aad0d12",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -443,7 +428,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1faa665f-8996-476f-9149-cb50c12208a0",
+                            "id": "d0c3c662-c87d-4dfe-baf4-5515a37a01eb",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -546,7 +531,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c0301a66-b403-41a4-b7cd-d046294cd058",
+                            "id": "8478d152-f5d9-429e-bfaf-8001a127fcfd",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -649,419 +634,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e4270ca4-5f68-4bdf-b150-93303b0b4370",
-                            "name": "Conflict",
-                            "originalRequest": {
-                                "url": {
-                                    "path": [
-                                        "ingeschrevenpersonen"
-                                    ],
-                                    "host": [
-                                        "{{baseUrl}}"
-                                    ],
-                                    "query": [
-                                        {
-                                            "key": "expand",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "fields",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "burgerservicenummer",
-                                            "value": "555555021,555555021"
-                                        },
-                                        {
-                                            "key": "geboorte__datum",
-                                            "value": "[object Object]"
-                                        },
-                                        {
-                                            "key": "geboorte__plaats",
-                                            "value": "Utrecht"
-                                        },
-                                        {
-                                            "key": "geslachtsaanduiding",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "inclusiefoverledenpersonen",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "key": "naam__geslachtsnaam",
-                                            "value": "Vries"
-                                        },
-                                        {
-                                            "key": "naam__voornamen",
-                                            "value": "Dirk"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__gemeentevaninschrijving",
-                                            "value": "0518"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisletter",
-                                            "value": "a"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummer",
-                                            "value": "14"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummertoevoeging",
-                                            "value": "bis"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__identificatiecodenummeraanduiding",
-                                            "value": "0518200000366054"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__naamopenbareruimte",
-                                            "value": "Tulpstraat"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__postcode",
-                                            "value": "2341SX"
-                                        },
-                                        {
-                                            "key": "naam__voorvoegsel",
-                                            "value": "de"
-                                        }
-                                    ],
-                                    "variable": []
-                                },
-                                "method": "GET",
-                                "body": {}
-                            },
-                            "status": "Conflict",
-                            "code": 409,
-                            "header": [
-                                {
-                                    "key": "api-version",
-                                    "value": "1.0.0",
-                                    "description": ""
-                                },
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/problem+json"
-                                }
-                            ],
-                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                            "cookie": [],
-                            "_postman_previewlanguage": "json"
-                        },
-                        {
-                            "id": "8f005234-4d0e-40e2-b9af-2a7bf07bc6c8",
-                            "name": "Gone",
-                            "originalRequest": {
-                                "url": {
-                                    "path": [
-                                        "ingeschrevenpersonen"
-                                    ],
-                                    "host": [
-                                        "{{baseUrl}}"
-                                    ],
-                                    "query": [
-                                        {
-                                            "key": "expand",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "fields",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "burgerservicenummer",
-                                            "value": "555555021,555555021"
-                                        },
-                                        {
-                                            "key": "geboorte__datum",
-                                            "value": "[object Object]"
-                                        },
-                                        {
-                                            "key": "geboorte__plaats",
-                                            "value": "Utrecht"
-                                        },
-                                        {
-                                            "key": "geslachtsaanduiding",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "inclusiefoverledenpersonen",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "key": "naam__geslachtsnaam",
-                                            "value": "Vries"
-                                        },
-                                        {
-                                            "key": "naam__voornamen",
-                                            "value": "Dirk"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__gemeentevaninschrijving",
-                                            "value": "0518"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisletter",
-                                            "value": "a"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummer",
-                                            "value": "14"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummertoevoeging",
-                                            "value": "bis"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__identificatiecodenummeraanduiding",
-                                            "value": "0518200000366054"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__naamopenbareruimte",
-                                            "value": "Tulpstraat"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__postcode",
-                                            "value": "2341SX"
-                                        },
-                                        {
-                                            "key": "naam__voorvoegsel",
-                                            "value": "de"
-                                        }
-                                    ],
-                                    "variable": []
-                                },
-                                "method": "GET",
-                                "body": {}
-                            },
-                            "status": "Gone",
-                            "code": 410,
-                            "header": [
-                                {
-                                    "key": "api-version",
-                                    "value": "1.0.0",
-                                    "description": ""
-                                },
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/problem+json"
-                                }
-                            ],
-                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                            "cookie": [],
-                            "_postman_previewlanguage": "json"
-                        },
-                        {
-                            "id": "592f144b-73b9-4aa7-9f18-cb419ca226cb",
-                            "name": "Unsupported Media Type",
-                            "originalRequest": {
-                                "url": {
-                                    "path": [
-                                        "ingeschrevenpersonen"
-                                    ],
-                                    "host": [
-                                        "{{baseUrl}}"
-                                    ],
-                                    "query": [
-                                        {
-                                            "key": "expand",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "fields",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "burgerservicenummer",
-                                            "value": "555555021,555555021"
-                                        },
-                                        {
-                                            "key": "geboorte__datum",
-                                            "value": "[object Object]"
-                                        },
-                                        {
-                                            "key": "geboorte__plaats",
-                                            "value": "Utrecht"
-                                        },
-                                        {
-                                            "key": "geslachtsaanduiding",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "inclusiefoverledenpersonen",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "key": "naam__geslachtsnaam",
-                                            "value": "Vries"
-                                        },
-                                        {
-                                            "key": "naam__voornamen",
-                                            "value": "Dirk"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__gemeentevaninschrijving",
-                                            "value": "0518"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisletter",
-                                            "value": "a"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummer",
-                                            "value": "14"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummertoevoeging",
-                                            "value": "bis"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__identificatiecodenummeraanduiding",
-                                            "value": "0518200000366054"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__naamopenbareruimte",
-                                            "value": "Tulpstraat"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__postcode",
-                                            "value": "2341SX"
-                                        },
-                                        {
-                                            "key": "naam__voorvoegsel",
-                                            "value": "de"
-                                        }
-                                    ],
-                                    "variable": []
-                                },
-                                "method": "GET",
-                                "body": {}
-                            },
-                            "status": "Unsupported Media Type",
-                            "code": 415,
-                            "header": [
-                                {
-                                    "key": "api-version",
-                                    "value": "1.0.0",
-                                    "description": ""
-                                },
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/problem+json"
-                                }
-                            ],
-                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                            "cookie": [],
-                            "_postman_previewlanguage": "json"
-                        },
-                        {
-                            "id": "ad063c2f-dbef-4a89-8567-c6703179745b",
-                            "name": "Too Many Requests",
-                            "originalRequest": {
-                                "url": {
-                                    "path": [
-                                        "ingeschrevenpersonen"
-                                    ],
-                                    "host": [
-                                        "{{baseUrl}}"
-                                    ],
-                                    "query": [
-                                        {
-                                            "key": "expand",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "fields",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "burgerservicenummer",
-                                            "value": "555555021,555555021"
-                                        },
-                                        {
-                                            "key": "geboorte__datum",
-                                            "value": "[object Object]"
-                                        },
-                                        {
-                                            "key": "geboorte__plaats",
-                                            "value": "Utrecht"
-                                        },
-                                        {
-                                            "key": "geslachtsaanduiding",
-                                            "value": "<string>"
-                                        },
-                                        {
-                                            "key": "inclusiefoverledenpersonen",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "key": "naam__geslachtsnaam",
-                                            "value": "Vries"
-                                        },
-                                        {
-                                            "key": "naam__voornamen",
-                                            "value": "Dirk"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__gemeentevaninschrijving",
-                                            "value": "0518"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisletter",
-                                            "value": "a"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummer",
-                                            "value": "14"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__huisnummertoevoeging",
-                                            "value": "bis"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__identificatiecodenummeraanduiding",
-                                            "value": "0518200000366054"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__naamopenbareruimte",
-                                            "value": "Tulpstraat"
-                                        },
-                                        {
-                                            "key": "verblijfplaats__postcode",
-                                            "value": "2341SX"
-                                        },
-                                        {
-                                            "key": "naam__voorvoegsel",
-                                            "value": "de"
-                                        }
-                                    ],
-                                    "variable": []
-                                },
-                                "method": "GET",
-                                "body": {}
-                            },
-                            "status": "Too Many Requests",
-                            "code": 429,
-                            "header": [
-                                {
-                                    "key": "api-version",
-                                    "value": "1.0.0",
-                                    "description": ""
-                                },
-                                {
-                                    "key": "Content-Type",
-                                    "value": "application/problem+json"
-                                }
-                            ],
-                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                            "cookie": [],
-                            "_postman_previewlanguage": "json"
-                        },
-                        {
-                            "id": "3262f734-f804-46a9-a371-07df5548c104",
+                            "id": "4d7c27f5-78b9-4c38-9a94-386c91c72f03",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -1164,7 +737,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "70733b92-5259-4577-a3f2-9b0f0e7dec3c",
+                            "id": "1034f4a5-041f-47e4-bbd2-cff83549d1dc",
                             "name": "Not Implemented",
                             "originalRequest": {
                                 "url": {
@@ -1267,7 +840,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7256d7fe-4e44-4e62-bbae-b63f14568963",
+                            "id": "9c557ee7-1aa7-443c-bf7f-5e36099ae8f3",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -1370,7 +943,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9779af67-1888-4956-b5b9-18c754686028",
+                            "id": "51100a1c-c56a-424c-a030-3caefa01a766",
                             "name": "Er is een onverwachte fout opgetreden",
                             "originalRequest": {
                                 "url": {
@@ -1476,11 +1049,11 @@
                     "event": []
                 },
                 {
-                    "id": "87e85c6b-71a1-4e80-8e92-cdc54bad2fe4",
+                    "id": "90cf5489-7534-4af7-ba60-fdbb2cbc2e44",
                     "name": "{burgerservicenummer}",
                     "item": [
                         {
-                            "id": "6aa708c8-b051-49b6-825c-2fab32436081",
+                            "id": "bbf284c0-2705-48d4-9bb1-81dbb05be1b2",
                             "name": "ingeschreven Natuurlijk Persoon",
                             "request": {
                                 "name": "ingeschreven Natuurlijk Persoon",
@@ -1522,7 +1095,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "d2614436-5b15-45ce-8e53-be5ce15cbc88",
+                                    "id": "4e9bbc1d-6e00-428e-b5a0-be32793048e7",
                                     "name": "Zoekactie geslaagd",
                                     "originalRequest": {
                                         "url": {
@@ -1567,21 +1140,6 @@
                                             "description": ""
                                         },
                                         {
-                                            "key": "X-Rate-Limit-Limit",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Remaining",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Reset",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
                                             "key": "Content-Type",
                                             "value": "application/hal+json"
                                         }
@@ -1591,7 +1149,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "79b1e1b3-7f88-4660-b595-06c398e0a452",
+                                    "id": "53c49c6f-8629-41d3-9061-3c482d637caf",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -1640,7 +1198,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f3ea7497-15ef-4d32-82ba-20899de7ab9f",
+                                    "id": "b39e6c21-ddfa-4b8c-953c-b7a5467ed4bd",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -1689,7 +1247,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "12498f8d-4c57-40f7-a638-1f316fc3922d",
+                                    "id": "6829019e-d234-4cae-a37a-fbf2493f0663",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -1738,7 +1296,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f1108232-61da-4d00-bde4-d10af304fac6",
+                                    "id": "041b3b7f-af23-40b7-ae86-c7f5ac48a99e",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -1787,7 +1345,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "8f4fd8a1-ccd2-4e1d-8902-5b1674f963f4",
+                                    "id": "7f81b599-b467-47e9-96f0-32612bd3f89c",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -1836,203 +1394,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "049d4b6c-ae65-41df-beb5-769100ca6278",
-                                    "name": "Conflict",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "expand",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Conflict",
-                                    "code": 409,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "95e88af7-ddee-4fac-9dad-533d56f4c23e",
-                                    "name": "Gone",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "expand",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Gone",
-                                    "code": 410,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "dc50a4d9-7a60-4190-8a6a-9b3f1e5d6902",
-                                    "name": "Unsupported Media Type",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "expand",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Unsupported Media Type",
-                                    "code": 415,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "62e1cf06-8ee1-46b3-9650-2d4ae2ce3824",
-                                    "name": "Too Many Requests",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "expand",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Too Many Requests",
-                                    "code": 429,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "16ae7124-6879-490c-b7f6-89ec05c0e07a",
+                                    "id": "838d4066-e4df-4758-bfcf-28dbf67d1fc8",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -2081,7 +1443,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "85f31c7c-cac6-40ce-beab-7f1ca5a70179",
+                                    "id": "82abbfa8-8a4c-4868-9e32-1f76e7afbe00",
                                     "name": "Not Implemented",
                                     "originalRequest": {
                                         "url": {
@@ -2130,7 +1492,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "eb4ec9d9-aa4c-4551-8045-e88233032980",
+                                    "id": "20012c29-03bc-416e-8484-f64a2076eb7e",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -2179,7 +1541,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "eb798e39-f461-43f2-90b8-5a2f2bfaa240",
+                                    "id": "78a19aca-9fa7-43df-8f15-16c2ad54bbf1",
                                     "name": "Er is een onverwachte fout opgetreden",
                                     "originalRequest": {
                                         "url": {
@@ -2231,11 +1593,11 @@
                             "event": []
                         },
                         {
-                            "id": "8a558ef9-689a-424d-adf6-4bdca55f2d84",
+                            "id": "11e20a65-734d-44a3-afa8-879d9d0d69a1",
                             "name": "kinderen",
                             "item": [
                                 {
-                                    "id": "125812d2-a03e-4bfd-8d9c-f27c1eb8b3f9",
+                                    "id": "50ef500f-866c-4604-ad81-5fdd813952bc",
                                     "name": "ingeschrevenpersonen Burgerservicenummerkinderen",
                                     "request": {
                                         "name": "ingeschrevenpersonen Burgerservicenummerkinderen",
@@ -2267,7 +1629,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "39bc2069-fb3a-4774-ab88-3b6bdac14254",
+                                            "id": "099635f3-1ae8-4dc6-815f-268cc03ae9b4",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -2304,21 +1666,6 @@
                                                     "description": ""
                                                 },
                                                 {
-                                                    "key": "X-Rate-Limit-Limit",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Remaining",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Reset",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
                                                     "key": "Content-Type",
                                                     "value": "application/hal+json"
                                                 }
@@ -2328,7 +1675,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e7e6b8f7-3a64-4ebf-a178-86d585787b38",
+                                            "id": "b547a472-db28-43eb-ae16-635f0d300748",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -2369,7 +1716,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "38e23401-1c64-4d33-94c0-27dca7d5bad6",
+                                            "id": "7a7ff89f-99f3-4d4d-bb5c-56ae852a31ef",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -2410,7 +1757,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "a5f12cac-2798-4c6e-a279-d8ac6a247afa",
+                                            "id": "b7ecce86-d749-4f8b-9952-dbd15d6965fa",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -2451,7 +1798,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1de7a439-1973-43ca-98ea-2b6c6280ac38",
+                                            "id": "0ce457c3-d86d-4ecc-b8ce-015cf3273b99",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -2492,7 +1839,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "7acbf2bb-4ef5-4b4a-aa2f-57eed942cb1d",
+                                            "id": "b70e4a0a-36de-4e60-8c5b-a7fa4a3d89db",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -2533,171 +1880,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "7e57b82e-9224-4845-a18a-ac5cf9568f85",
-                                            "name": "Conflict",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Conflict",
-                                            "code": 409,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "2ef79f3b-d8d5-4090-84d8-0fba3486361e",
-                                            "name": "Gone",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Gone",
-                                            "code": 410,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "f88e1b24-830d-4576-ad18-189ef3c0683f",
-                                            "name": "Unsupported Media Type",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Unsupported Media Type",
-                                            "code": 415,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "49d8fd86-5d2a-442c-8592-2e3ad6ab3a21",
-                                            "name": "Too Many Requests",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Too Many Requests",
-                                            "code": 429,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "02880fdd-3f9c-472c-9482-0e54d88d3820",
+                                            "id": "8446416a-bb46-40ac-a9a5-73411241c8cb",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -2738,7 +1921,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "73abc9d4-4c98-40ae-abb8-5900f31a8ba0",
+                                            "id": "b25ffac7-beb2-4905-b9f2-25f3a4d951cd",
                                             "name": "Not Implemented",
                                             "originalRequest": {
                                                 "url": {
@@ -2779,7 +1962,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "43f4f003-aaa2-49e1-8fa8-5c902840879a",
+                                            "id": "756abbf3-b186-489b-b8bb-57de43847a73",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -2820,7 +2003,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "26dec36b-7b3a-4906-89fa-4ff35ea10d07",
+                                            "id": "69e76e3f-b823-45f8-ac1e-f262ef8e0f5b",
                                             "name": "Er is een onverwachte fout opgetreden",
                                             "originalRequest": {
                                                 "url": {
@@ -2864,7 +2047,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "f6472a5e-ddf4-4308-959a-c68227ef8dbf",
+                                    "id": "cc18a8ae-fc29-4892-8b03-fffb59cfd485",
                                     "name": "ingeschrevenpersonen Burgerservicenummerkinderen Id",
                                     "request": {
                                         "name": "ingeschrevenpersonen Burgerservicenummerkinderen Id",
@@ -2903,7 +2086,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "98dd3991-1a2a-4731-815a-0bb46cfb93e3",
+                                            "id": "26a43156-f020-43c0-bc93-d10549662b4c",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -2945,21 +2128,6 @@
                                                     "description": ""
                                                 },
                                                 {
-                                                    "key": "X-Rate-Limit-Limit",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Remaining",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Reset",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
                                                     "key": "Content-Type",
                                                     "value": "application/hal+json"
                                                 }
@@ -2969,7 +2137,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "71818086-66b9-4436-8d3c-90d218a67fcd",
+                                            "id": "d28d7c31-213c-418c-8cbe-3d65ae41b372",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -3015,7 +2183,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c2f4e9a1-aa38-4f43-9c9d-907f65271e9b",
+                                            "id": "dbc0fe44-282c-4279-b0dd-c69797810454",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -3061,7 +2229,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e12b410e-c2a9-457b-9821-628f884a348d",
+                                            "id": "a8248ea0-20f6-4c17-b9b1-4565c904eef8",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -3107,7 +2275,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "9486f9a6-f0a3-480a-afd4-5e404a1d1829",
+                                            "id": "54b646d4-46a4-48ea-9668-3a449158e195",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -3153,7 +2321,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "58458242-faac-468b-893d-fd4e0c41d081",
+                                            "id": "96eb210c-d31b-4762-8924-87cc28615575",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -3199,191 +2367,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "222dacb9-1f00-4acf-b2cf-c653d90f00ad",
-                                            "name": "Conflict",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Conflict",
-                                            "code": 409,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "830fd7ed-a545-40c5-8634-d6d1bcd719b4",
-                                            "name": "Gone",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Gone",
-                                            "code": 410,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "c98eb75c-7093-4a96-977f-311985099c3b",
-                                            "name": "Unsupported Media Type",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Unsupported Media Type",
-                                            "code": 415,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "e95317fb-bf5c-4548-a939-ff746c0f5aa6",
-                                            "name": "Too Many Requests",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "kinderen",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Too Many Requests",
-                                            "code": 429,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "76e169f6-3b00-4ed7-9bd7-82d457ace67b",
+                                            "id": "e488cd95-fd2c-486f-a376-ffa4ac141c50",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -3429,7 +2413,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b5807aa6-2bc7-4296-ac8f-65f31f702ee0",
+                                            "id": "fbe1c524-05b6-4f65-90ed-8f2d215c07bb",
                                             "name": "Not Implemented",
                                             "originalRequest": {
                                                 "url": {
@@ -3475,7 +2459,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "00f19d37-a082-4218-840f-1bf5e78fa1d2",
+                                            "id": "f84facd5-6c08-4781-93f1-2d953700f218",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -3521,7 +2505,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "3862fc60-eb0f-411e-a0a4-682daa899eee",
+                                            "id": "90498632-a22f-4f2c-857c-b56c672b772e",
                                             "name": "Er is een onverwachte fout opgetreden",
                                             "originalRequest": {
                                                 "url": {
@@ -3573,11 +2557,11 @@
                             "event": []
                         },
                         {
-                            "id": "c8a39d16-09a8-4ed7-add4-e772debc63e3",
+                            "id": "897daec2-c96c-49e4-b00d-2788aae55c55",
                             "name": "ouders",
                             "item": [
                                 {
-                                    "id": "c2382ac7-17d0-4839-9b32-98603e94b2e4",
+                                    "id": "7424585c-eb97-472d-a99f-b2d05e581af6",
                                     "name": "ingeschrevenpersonen Burgerservicenummerouders",
                                     "request": {
                                         "name": "ingeschrevenpersonen Burgerservicenummerouders",
@@ -3609,7 +2593,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "e62c8b81-af84-47b9-b8ed-fc18d4c01aff",
+                                            "id": "86fa5543-70c2-45af-9016-a20382d617df",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -3646,21 +2630,6 @@
                                                     "description": ""
                                                 },
                                                 {
-                                                    "key": "X-Rate-Limit-Limit",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Remaining",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Reset",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
                                                     "key": "Content-Type",
                                                     "value": "application/hal+json"
                                                 }
@@ -3670,7 +2639,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "7ee765e8-5c2f-47ea-a344-8957236e2131",
+                                            "id": "65462738-0225-4bda-ad1d-37848adde3d1",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -3711,7 +2680,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "488158b4-a41c-4227-84da-b84736cf888b",
+                                            "id": "69af553b-749e-4948-8802-bf14a18d51f0",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -3752,7 +2721,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "fd52e23a-67b3-458b-8c2e-d5eea18b547b",
+                                            "id": "d843be9a-c2eb-42de-80d5-129fdc03cb31",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -3793,7 +2762,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "62783f86-3489-4b36-836f-bd967a74ab1f",
+                                            "id": "ce5bee7d-21fc-480f-a65d-285949da1e31",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -3834,7 +2803,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "947d845e-7c1d-4f3a-88a5-c54737b53245",
+                                            "id": "88864438-6f24-4c06-91d7-c9daa3b161b3",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -3875,171 +2844,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1edccf23-65c7-4166-91b9-a0b67bb6575e",
-                                            "name": "Conflict",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Conflict",
-                                            "code": 409,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "8a4e1bab-43e8-4ae2-87c2-42fc42971932",
-                                            "name": "Gone",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Gone",
-                                            "code": 410,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "d788bc54-025b-496b-8c77-ee1bb1af0a9a",
-                                            "name": "Unsupported Media Type",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Unsupported Media Type",
-                                            "code": 415,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "db91a562-c129-4e2d-a94d-5738a05c971b",
-                                            "name": "Too Many Requests",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Too Many Requests",
-                                            "code": 429,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "18b73931-7298-4d0c-8fcb-3b523caac681",
+                                            "id": "5324aaef-2ebe-441b-8b82-5324d2825ffc",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -4080,7 +2885,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "8e5dedad-1ddc-4865-822d-b83dba7d6fb1",
+                                            "id": "ba777d1e-aef1-4484-bf49-f981f2d1de75",
                                             "name": "Not Implemented",
                                             "originalRequest": {
                                                 "url": {
@@ -4121,7 +2926,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b462463c-a68c-4936-89c7-5c4b071ca1a3",
+                                            "id": "a97a1151-9a5e-4197-87fd-96f68ccd30de",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -4162,7 +2967,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5cb6de4f-b9b0-41fb-8497-0f118560fee6",
+                                            "id": "d3a30570-a107-4532-9142-3ab4f91a0a1b",
                                             "name": "Er is een onverwachte fout opgetreden",
                                             "originalRequest": {
                                                 "url": {
@@ -4206,7 +3011,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "241bf002-602d-4e1a-aeff-830e002a55a6",
+                                    "id": "be84ba4f-1d6d-4e96-82b9-df438c4f3b4d",
                                     "name": "ingeschrevenpersonen Burgerservicenummerouders Id",
                                     "request": {
                                         "name": "ingeschrevenpersonen Burgerservicenummerouders Id",
@@ -4245,7 +3050,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "a46f94e7-6039-49d4-886e-cf6771f265bb",
+                                            "id": "7815be8e-b59a-46d1-b3f2-b358605f63f5",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -4287,21 +3092,6 @@
                                                     "description": ""
                                                 },
                                                 {
-                                                    "key": "X-Rate-Limit-Limit",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Remaining",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Reset",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
                                                     "key": "Content-Type",
                                                     "value": "application/hal+json"
                                                 }
@@ -4311,7 +3101,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "9d8c1b16-9f0c-4e3c-9d24-40d9a71afe93",
+                                            "id": "bec45b26-1e67-4d60-b7c9-2edae11d1b42",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -4357,7 +3147,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "f7d126fc-5899-4e22-86b4-6019d0e651fd",
+                                            "id": "f6f09b34-a118-459a-ac42-c8f4ee2c4b56",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -4403,7 +3193,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "a5725b11-8782-43c3-aa8a-d82213b8e9a9",
+                                            "id": "847a0c4c-4e3d-4547-9331-009f7ad59c37",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -4449,7 +3239,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "371a4928-ecac-41fd-9f3b-22cfe414a8d6",
+                                            "id": "9ec726f2-f335-468e-b090-3a1645522ca7",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -4495,7 +3285,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "bb8e3c79-3162-49e1-ac1a-58ca3e15f26a",
+                                            "id": "5412960f-ad65-42b7-8f4b-c616e2c10ba7",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -4541,191 +3331,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "6ca868de-64a1-41ec-9479-fb9e153fd223",
-                                            "name": "Conflict",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Conflict",
-                                            "code": 409,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "26c68995-11c0-4314-b894-41a87f2bb1c1",
-                                            "name": "Gone",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Gone",
-                                            "code": 410,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "cb499c05-2983-41db-9a45-7cd21165a17e",
-                                            "name": "Unsupported Media Type",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Unsupported Media Type",
-                                            "code": 415,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "3230f0d7-d81e-4566-b5c0-0020ce3dd9c4",
-                                            "name": "Too Many Requests",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "ouders",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Too Many Requests",
-                                            "code": 429,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "5d4e2a2c-9b92-4303-91c4-2b9ad73f87e2",
+                                            "id": "c5901f8b-95ef-40c6-a2c2-7fe9fff610d1",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -4771,7 +3377,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "823861d8-5e70-4a87-96ed-5bff25ef41e7",
+                                            "id": "06a1e27a-78bc-4b02-be69-a73400737abc",
                                             "name": "Not Implemented",
                                             "originalRequest": {
                                                 "url": {
@@ -4817,7 +3423,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b286ce84-022a-4753-a811-f56f25d7ae6e",
+                                            "id": "761ff959-bdf4-4a70-ab56-a8b0945addd2",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -4863,7 +3469,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "3af4bfae-280e-4883-8aec-888f70928c52",
+                                            "id": "7e4d6ae1-3251-495c-936c-c598fdfd3e3a",
                                             "name": "Er is een onverwachte fout opgetreden",
                                             "originalRequest": {
                                                 "url": {
@@ -4915,11 +3521,11 @@
                             "event": []
                         },
                         {
-                            "id": "8dff9c58-c386-4641-8dc8-b6c3fb5a0e05",
+                            "id": "369d42ef-b8e0-4eec-b23e-9ee91b13c2e2",
                             "name": "partners",
                             "item": [
                                 {
-                                    "id": "222016f2-7708-4d2b-afe1-ea9ccf3e529a",
+                                    "id": "1a0917de-6267-4f06-bd35-da8f233fa2cc",
                                     "name": "ingeschrevenpersonen Burgerservicenummerpartners",
                                     "request": {
                                         "name": "ingeschrevenpersonen Burgerservicenummerpartners",
@@ -4951,7 +3557,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "916678c9-a3ac-4d63-8323-2d0f32c36101",
+                                            "id": "bd4a10a5-cf78-41d9-93b1-e5019a6cb13f",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -4988,21 +3594,6 @@
                                                     "description": ""
                                                 },
                                                 {
-                                                    "key": "X-Rate-Limit-Limit",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Remaining",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Reset",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
                                                     "key": "Content-Type",
                                                     "value": "application/hal+json"
                                                 }
@@ -5012,7 +3603,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "7c98ba29-0b09-410d-92b5-e6eadee05cc0",
+                                            "id": "a698ec28-f427-433b-afc9-3d694bff56c1",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -5053,7 +3644,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "a4cbbff5-fc61-42ce-83c3-1adacc7de35c",
+                                            "id": "6d96bb81-01a8-4d14-936b-913f26456a6d",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -5094,7 +3685,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "fc035129-3bf7-4c01-9038-7ef84edc6a14",
+                                            "id": "8dbf55d7-1010-467b-8a08-2df40be83d65",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -5135,7 +3726,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d07f95dc-bcf6-4dfe-91c5-b8a9bd7e10c5",
+                                            "id": "9fce6074-bdbe-44d6-b48e-78dcf7399489",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -5176,7 +3767,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "0c7b6632-1349-4bf6-988f-688fef56f0e6",
+                                            "id": "7bea50ba-a486-4b3a-aa02-e16976464a90",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -5217,171 +3808,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5bc5e922-a45a-49d0-998d-d4ae7b4456f3",
-                                            "name": "Conflict",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Conflict",
-                                            "code": 409,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "fc28ae15-52a6-4680-8f8a-80e07aa4f1fd",
-                                            "name": "Gone",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Gone",
-                                            "code": 410,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "29be326a-538c-476f-b951-46d381f36389",
-                                            "name": "Unsupported Media Type",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Unsupported Media Type",
-                                            "code": 415,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "a4d6a214-47a0-4c60-a425-82628508b21f",
-                                            "name": "Too Many Requests",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Too Many Requests",
-                                            "code": 429,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "bb4dc733-e112-45c6-9639-9bd3222cbded",
+                                            "id": "8bb1dce5-fb15-4b2a-af40-96f19bfd5494",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -5422,7 +3849,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b788cb1f-1dd6-4d04-bcff-1db7e0d6c08a",
+                                            "id": "999d1ad6-e0b0-4487-93aa-67f9f291d76e",
                                             "name": "Not Implemented",
                                             "originalRequest": {
                                                 "url": {
@@ -5463,7 +3890,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c1d4026f-0920-465b-a0f4-d44ad2e2f4b0",
+                                            "id": "c1f14739-55fa-47e0-bec8-b00b59206e0d",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -5504,7 +3931,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "af80bc1d-fd68-4aa2-8512-14909e032279",
+                                            "id": "bad720a6-0e7a-494f-8000-4db346e44cf5",
                                             "name": "Er is een onverwachte fout opgetreden",
                                             "originalRequest": {
                                                 "url": {
@@ -5548,7 +3975,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "21401c17-0707-404e-80d5-77b5a3470cb7",
+                                    "id": "b7a905b4-4fc4-4ecd-bf35-2713298c5905",
                                     "name": "ingeschrevenpersonen Burgerservicenummerpartners Id",
                                     "request": {
                                         "name": "ingeschrevenpersonen Burgerservicenummerpartners Id",
@@ -5587,7 +4014,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "51a713c5-df79-4c13-9357-7adbf46ff768",
+                                            "id": "e1856c3a-1524-4e60-b812-cad03878fabe",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -5629,21 +4056,6 @@
                                                     "description": ""
                                                 },
                                                 {
-                                                    "key": "X-Rate-Limit-Limit",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Remaining",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "X-Rate-Limit-Reset",
-                                                    "value": "<integer>",
-                                                    "description": ""
-                                                },
-                                                {
                                                     "key": "Content-Type",
                                                     "value": "application/hal+json"
                                                 }
@@ -5653,7 +4065,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "8a59b286-1013-429e-885c-bc15ef2a2748",
+                                            "id": "7029d425-56c3-4836-ae32-469560c5be6b",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -5699,7 +4111,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "922f3bdd-acd5-496d-9211-958bf232f948",
+                                            "id": "10050e78-0aa7-4cf7-8042-bbb11d60c105",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -5745,7 +4157,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1db68692-84c7-4c0c-b95a-1760b93daa2d",
+                                            "id": "7c3e730c-cde7-4b9e-a97c-69178c03e9fd",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -5791,7 +4203,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c0f0eaf0-d2f2-4247-ad16-cedcd0b385b7",
+                                            "id": "85e909f6-b635-421f-9e0c-023e03c0b14e",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -5837,7 +4249,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5f1dea14-28b9-421a-9330-7a9ca632642a",
+                                            "id": "40254964-b975-4f98-bbc6-4ca2b3b82576",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -5883,191 +4295,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d3449cf7-790e-42c8-99e9-75bcb3946f56",
-                                            "name": "Conflict",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Conflict",
-                                            "code": 409,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "4fc23264-9e42-4539-854d-7301ed683577",
-                                            "name": "Gone",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Gone",
-                                            "code": 410,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "bb586596-9b26-4e2c-bd57-089ef0846e93",
-                                            "name": "Unsupported Media Type",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Unsupported Media Type",
-                                            "code": 415,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "79ad574d-4d30-45ca-a642-071509cd5137",
-                                            "name": "Too Many Requests",
-                                            "originalRequest": {
-                                                "url": {
-                                                    "path": [
-                                                        "ingeschrevenpersonen",
-                                                        ":burgerservicenummer",
-                                                        "partners",
-                                                        ":id"
-                                                    ],
-                                                    "host": [
-                                                        "{{baseUrl}}"
-                                                    ],
-                                                    "query": [],
-                                                    "variable": [
-                                                        {
-                                                            "type": "any",
-                                                            "key": "burgerservicenummer"
-                                                        },
-                                                        {
-                                                            "type": "any",
-                                                            "key": "id"
-                                                        }
-                                                    ]
-                                                },
-                                                "method": "GET",
-                                                "body": {}
-                                            },
-                                            "status": "Too Many Requests",
-                                            "code": 429,
-                                            "header": [
-                                                {
-                                                    "key": "api-version",
-                                                    "value": "1.0.0",
-                                                    "description": ""
-                                                },
-                                                {
-                                                    "key": "Content-Type",
-                                                    "value": "application/problem+json"
-                                                }
-                                            ],
-                                            "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                            "cookie": [],
-                                            "_postman_previewlanguage": "json"
-                                        },
-                                        {
-                                            "id": "490cc1b8-3c87-4e27-943b-a076197a90eb",
+                                            "id": "4be56836-282f-4c7a-8e6b-f41f51496253",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -6113,7 +4341,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "9b58ee9f-325f-4efb-be5f-650d9534db26",
+                                            "id": "b191aff4-bc62-4a7b-afa3-a5e60afc7b74",
                                             "name": "Not Implemented",
                                             "originalRequest": {
                                                 "url": {
@@ -6159,7 +4387,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "0a6a2c1d-7dfa-41b9-b64d-35d7e44a4eb9",
+                                            "id": "318fc178-3902-4ed1-80ba-cbfa0ae01082",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -6205,7 +4433,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "172c06be-3d84-4820-a1c1-0cf8bad556c0",
+                                            "id": "1ff99bc5-5e32-4b6b-96d8-b00f08fc59aa",
                                             "name": "Er is een onverwachte fout opgetreden",
                                             "originalRequest": {
                                                 "url": {
@@ -6257,7 +4485,7 @@
                             "event": []
                         },
                         {
-                            "id": "5aca6f8d-da57-4f86-b4e8-21a909135be2",
+                            "id": "90f922d2-e390-4b5d-82ef-b65f9a4b5437",
                             "name": "Getverblijfplaatshistorie",
                             "request": {
                                 "name": "Getverblijfplaatshistorie",
@@ -6310,7 +4538,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "0d407c3d-4cec-41f9-a088-a939de635e1b",
+                                    "id": "fc296ac3-84bd-4459-86f6-37613f5cc65b",
                                     "name": "Zoekactie geslaagd",
                                     "originalRequest": {
                                         "url": {
@@ -6364,21 +4592,6 @@
                                             "description": ""
                                         },
                                         {
-                                            "key": "X-Rate-Limit-Limit",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Remaining",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Reset",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
                                             "key": "Content-Type",
                                             "value": "application/hal+json"
                                         }
@@ -6388,7 +4601,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ef1a826b-0e25-4c00-a69c-19d0b5b691ad",
+                                    "id": "bd7cce8f-c49f-4f2b-b8ce-f07b9b6a073e",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -6446,7 +4659,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c94da445-7cf3-43e6-b533-295126d8b760",
+                                    "id": "cb916ac2-1708-4e31-8606-f67d09727c31",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -6504,7 +4717,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c6970364-97c7-4a5d-95c9-b3118e2596dd",
+                                    "id": "a452f9e8-486b-4c12-ac25-060cdf58b628",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -6562,7 +4775,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e98538ca-5b4d-47e5-90cc-7f28750ffa71",
+                                    "id": "95084e49-a961-4f46-b2e9-e4a8d2c45131",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -6620,7 +4833,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "1585c013-649f-4913-8595-f7b962a3e096",
+                                    "id": "f4f458c8-3f1e-4374-991b-eb0cbb43fc87",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -6678,239 +4891,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7cf08f1d-1ce5-4691-9043-13ab7fd82378",
-                                    "name": "Conflict",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfplaatshistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Conflict",
-                                    "code": 409,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "6b1f88e4-51ee-42bf-85fe-27d4592217b1",
-                                    "name": "Gone",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfplaatshistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Gone",
-                                    "code": 410,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "5937b278-07e3-4e87-86af-8ec8c6a5d9ae",
-                                    "name": "Unsupported Media Type",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfplaatshistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Unsupported Media Type",
-                                    "code": 415,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "bbfd783b-0e6a-40e8-a981-9cf8b58dc250",
-                                    "name": "Too Many Requests",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfplaatshistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Too Many Requests",
-                                    "code": 429,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "0b14f373-6275-425e-8347-741a21b2ea9c",
+                                    "id": "0915794b-30a3-47b3-84d9-e25a9c3d3062",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -6968,7 +4949,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ff62c8a3-905d-4c36-aa0c-226cd17595c2",
+                                    "id": "790b6204-9e2c-4dac-90a1-b730bf6dd052",
                                     "name": "Not Implemented",
                                     "originalRequest": {
                                         "url": {
@@ -7026,7 +5007,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "3c326677-816e-4dd3-ab43-25d7873a2f8f",
+                                    "id": "856d5ecc-a9eb-48d1-99df-c66480f23aa4",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -7084,7 +5065,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "94f8d1f4-ba48-4899-a1cb-f354da5fac3b",
+                                    "id": "f9a160ba-c106-4c64-8975-c584a2df0342",
                                     "name": "Er is een onverwachte fout opgetreden",
                                     "originalRequest": {
                                         "url": {
@@ -7145,7 +5126,7 @@
                             "event": []
                         },
                         {
-                            "id": "f85a06cc-b9b4-442a-b4bf-1840ee8ea3be",
+                            "id": "4397781a-388b-4419-a45c-757e305d0104",
                             "name": "Getpartnerhistorie",
                             "request": {
                                 "name": "Getpartnerhistorie",
@@ -7198,7 +5179,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "228714f2-c6b1-4b2b-9019-227ba8ab93c3",
+                                    "id": "02ed327e-76b7-41dd-8a80-de1c9bdc2da9",
                                     "name": "Zoekactie geslaagd",
                                     "originalRequest": {
                                         "url": {
@@ -7252,21 +5233,6 @@
                                             "description": ""
                                         },
                                         {
-                                            "key": "X-Rate-Limit-Limit",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Remaining",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Reset",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
                                             "key": "Content-Type",
                                             "value": "application/hal+json"
                                         }
@@ -7276,7 +5242,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "4993e001-47c1-4d0c-9961-7f71311e1e14",
+                                    "id": "1f5ff0a3-6b72-4207-9c80-75875128d157",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -7334,7 +5300,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "413b3ac2-a7d8-45a0-950a-aeb7778ebbf9",
+                                    "id": "d195e4d3-0e2a-40cd-8322-e354c41b17e8",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -7392,7 +5358,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e2081405-8b4e-482b-9c66-2a689da746a3",
+                                    "id": "d140537b-e43d-491d-b276-3f6bd0d37076",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -7450,7 +5416,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c6036f5c-3dd1-4ea5-ae57-3ff4944e373f",
+                                    "id": "f9e40b2b-60a2-47e4-bd4c-5cd09335d929",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -7508,7 +5474,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "034ffc9c-4c5b-4d8e-aeb0-222e784225f5",
+                                    "id": "e3dabd08-29a6-40a4-9664-83e9f6aa03cc",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -7566,239 +5532,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "643af0d2-2126-49a1-b5fe-a59b101b8ded",
-                                    "name": "Conflict",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "partnerhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Conflict",
-                                    "code": 409,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "46be8879-e3ca-4a39-9600-8f0eca08ca5d",
-                                    "name": "Gone",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "partnerhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Gone",
-                                    "code": 410,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "2e59dbd1-cc5c-4e03-8afa-807a041ab5b9",
-                                    "name": "Unsupported Media Type",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "partnerhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Unsupported Media Type",
-                                    "code": 415,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "5e46c5f8-c8ac-42e5-aad9-aa2076c715d7",
-                                    "name": "Too Many Requests",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "partnerhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Too Many Requests",
-                                    "code": 429,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "d3cc99cc-cc86-4fb4-a29a-b74de0f53277",
+                                    "id": "1e90ed45-f1fe-4550-961e-a316506659df",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -7856,7 +5590,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "6bc418a3-bfc1-4134-a2d5-12ba213a4b9c",
+                                    "id": "052857c5-e59a-4551-ac4a-a8b3fe6b21e7",
                                     "name": "Not Implemented",
                                     "originalRequest": {
                                         "url": {
@@ -7914,7 +5648,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "98357df0-1d81-41cc-8215-e6b878db5e9b",
+                                    "id": "bf616302-c037-49a2-9936-5e58e1dd3dc8",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -7972,7 +5706,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "c79de297-680a-4ff0-8e7d-9f3820478c14",
+                                    "id": "7cda26f4-8ea2-4aa2-8d92-d272f0be416e",
                                     "name": "Er is een onverwachte fout opgetreden",
                                     "originalRequest": {
                                         "url": {
@@ -8033,7 +5767,7 @@
                             "event": []
                         },
                         {
-                            "id": "41c83d55-2adb-419d-b075-f7a653551394",
+                            "id": "1a26afe6-ba17-4837-892f-3889477e73c1",
                             "name": "getverblijfstitelhistorie",
                             "request": {
                                 "name": "getverblijfstitelhistorie",
@@ -8086,7 +5820,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "e1ef57cc-09ba-445e-9f59-47ba78e51911",
+                                    "id": "d186274d-f98e-4e27-9a4c-ed3d4597175e",
                                     "name": "Zoekactie geslaagd",
                                     "originalRequest": {
                                         "url": {
@@ -8140,21 +5874,6 @@
                                             "description": ""
                                         },
                                         {
-                                            "key": "X-Rate-Limit-Limit",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Remaining",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Reset",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
                                             "key": "Content-Type",
                                             "value": "application/hal+json"
                                         }
@@ -8164,7 +5883,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "bdec8a1f-26ac-460c-8fb7-8ba1069428bc",
+                                    "id": "7b0fd323-ed0f-4679-9bbe-b94fff75be70",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -8222,7 +5941,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "546670f3-d72c-4ca3-9cbd-37f7158ea157",
+                                    "id": "022c5e1c-82b9-417a-9803-eca68807d6aa",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -8280,7 +5999,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "9ffc0076-839f-40eb-966e-9bf21ec06400",
+                                    "id": "206ba4f9-f0a0-4497-a96e-730138a14e46",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -8338,7 +6057,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e6221aec-9a6e-4838-b7c9-2d5de8f599fc",
+                                    "id": "a6f81e6c-b2ad-432f-9a06-d51ff733e3cf",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -8396,7 +6115,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "dc6f354b-1498-4d8d-bb69-344e4962c4dd",
+                                    "id": "de6b1286-7db5-4258-a541-f338e68ed375",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -8454,239 +6173,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "17c91c84-f848-48a0-a3aa-2a2d82813394",
-                                    "name": "Conflict",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfstitelhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Conflict",
-                                    "code": 409,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "c16e26e6-f1f7-4be1-a353-7276baf1bd01",
-                                    "name": "Gone",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfstitelhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Gone",
-                                    "code": 410,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "b1d71682-3377-49a4-98fd-7841b690c23f",
-                                    "name": "Unsupported Media Type",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfstitelhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Unsupported Media Type",
-                                    "code": 415,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "2c692a56-e9dc-4c92-a814-acae00469f78",
-                                    "name": "Too Many Requests",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "verblijfstitelhistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Too Many Requests",
-                                    "code": 429,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "93da2581-4c3b-4643-a1df-d8a7c027cda7",
+                                    "id": "78cc3f16-27e9-470e-bb96-3d4d5c555f05",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -8744,7 +6231,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7a59964d-bcfc-4cd7-9dc1-46b98b52b50e",
+                                    "id": "bef97a0c-c98a-46f6-9ca7-c41607fad252",
                                     "name": "Not Implemented",
                                     "originalRequest": {
                                         "url": {
@@ -8802,7 +6289,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "af990b20-cae5-4d37-8bba-2e52c76f7e93",
+                                    "id": "2075c97a-f9d4-489e-a2d1-82b5cc426949",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -8860,7 +6347,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "4b60a808-06c8-4602-a214-df7b0abcd1f8",
+                                    "id": "06d879dd-913e-41fa-b408-e64794b2a94e",
                                     "name": "Er is een onverwachte fout opgetreden",
                                     "originalRequest": {
                                         "url": {
@@ -8921,7 +6408,7 @@
                             "event": []
                         },
                         {
-                            "id": "4b1dd9c2-fafa-4ae4-bb5a-7badd58bf738",
+                            "id": "357c02ba-8654-4738-84f0-544d50a1d266",
                             "name": "getnationaliteithistorie",
                             "request": {
                                 "name": "getnationaliteithistorie",
@@ -8974,7 +6461,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "2b25ef0f-5e62-4145-ba7d-7330d661acee",
+                                    "id": "2d6ad673-1432-4dd7-870e-b0055f2f2de2",
                                     "name": "Zoekactie geslaagd",
                                     "originalRequest": {
                                         "url": {
@@ -9028,21 +6515,6 @@
                                             "description": ""
                                         },
                                         {
-                                            "key": "X-Rate-Limit-Limit",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Remaining",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "X-Rate-Limit-Reset",
-                                            "value": "<integer>",
-                                            "description": ""
-                                        },
-                                        {
                                             "key": "Content-Type",
                                             "value": "application/hal+json"
                                         }
@@ -9052,7 +6524,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f03fbe9a-5afc-4d23-9e27-1ad03f49c118",
+                                    "id": "d4bc108b-f4d5-425b-83a1-6e72ef7cb76b",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -9110,7 +6582,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2396a1a0-c015-425e-b2e9-19d9f47293df",
+                                    "id": "5764f405-f4bf-45d0-95de-088bdbf9a10c",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -9168,7 +6640,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "e3039cef-de16-4b95-abfb-7fca178051fe",
+                                    "id": "beb45290-98da-4ac7-8a71-cfa4f7792b42",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -9226,7 +6698,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "1ca87721-f1b3-4b07-890f-af10db6535e3",
+                                    "id": "6ccc79d5-bc93-422a-acd5-5934295c50dd",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -9284,7 +6756,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "0a861de4-3df3-4b41-8fe8-5a0d9ec18d7b",
+                                    "id": "54a8636b-95a9-43c8-bcd5-44dcc757862c",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -9342,239 +6814,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "1021db8d-c33b-4fce-a745-caa16e784d9f",
-                                    "name": "Conflict",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "nationaliteithistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Conflict",
-                                    "code": 409,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.10 409 Conflict\",\n \"title\": \"Conflict\",\n \"status\": 409,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"conflict\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "c6679f08-fb82-425c-8c46-687be4b57448",
-                                    "name": "Gone",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "nationaliteithistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Gone",
-                                    "code": 410,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.11 410 Gone\",\n \"title\": \"Gone\",\n \"status\": 410,\n \"detail\": \"The request could not be completed due to a conflict with the current state of the resource\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"gone\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "907f683f-1d58-4fb9-a11a-47138f01f2f0",
-                                    "name": "Unsupported Media Type",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "nationaliteithistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Unsupported Media Type",
-                                    "code": 415,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#/10.4.16 415 Unsupported Media Type\",\n \"title\": \"Unsupported Media Type\",\n \"status\": 415,\n \"detail\": \"The server is refusing the request because the entity of the request is in a format not supported by the requested resource for the requested method.\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"unsupported\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "df1f555c-869b-405e-a7cf-404eac26e317",
-                                    "name": "Too Many Requests",
-                                    "originalRequest": {
-                                        "url": {
-                                            "path": [
-                                                "ingeschrevenpersonen",
-                                                ":burgerservicenummer",
-                                                "nationaliteithistorie"
-                                            ],
-                                            "host": [
-                                                "{{baseUrl}}"
-                                            ],
-                                            "query": [
-                                                {
-                                                    "key": "fields",
-                                                    "value": "<string>"
-                                                },
-                                                {
-                                                    "key": "peildatum",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumvan",
-                                                    "value": "[object Object]"
-                                                },
-                                                {
-                                                    "key": "datumtotenmet",
-                                                    "value": "[object Object]"
-                                                }
-                                            ],
-                                            "variable": [
-                                                {
-                                                    "type": "any",
-                                                    "key": "burgerservicenummer"
-                                                }
-                                            ]
-                                        },
-                                        "method": "GET",
-                                        "body": {}
-                                    },
-                                    "status": "Too Many Requests",
-                                    "code": 429,
-                                    "header": [
-                                        {
-                                            "key": "api-version",
-                                            "value": "1.0.0",
-                                            "description": ""
-                                        },
-                                        {
-                                            "key": "Content-Type",
-                                            "value": "application/problem+json"
-                                        }
-                                    ],
-                                    "body": "{\n \"type\": \"https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\",\n \"title\": \"Too many request\",\n \"status\": 429,\n \"detail\": \"The user has sent too many requests in a given amount of time (rate limiting).\",\n \"instance\": \"https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde\",\n \"code\": \"tooManyRequests\"\n}",
-                                    "cookie": [],
-                                    "_postman_previewlanguage": "json"
-                                },
-                                {
-                                    "id": "47b0bdb6-7c35-41ad-805a-d53dc9a9267d",
+                                    "id": "d54d902d-98f6-42f8-aee8-6dffc1634c0c",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -9632,7 +6872,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "77b820a9-8f65-4e86-885d-fa8d4f2fd680",
+                                    "id": "f256c67f-c2c4-4674-a1aa-b40896ac560d",
                                     "name": "Not Implemented",
                                     "originalRequest": {
                                         "url": {
@@ -9690,7 +6930,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "abb8d32e-cb5c-415b-a1c8-92afbc5521e9",
+                                    "id": "7fa84e97-bee1-47ca-84d7-f20638d36cd1",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -9748,7 +6988,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "de12c9fb-cbc8-42a6-a3c2-38911cea99f9",
+                                    "id": "844b4683-2050-44af-8d86-35dcd0c0f838",
                                     "name": "Er is een onverwachte fout opgetreden",
                                     "originalRequest": {
                                         "url": {
@@ -9824,7 +7064,7 @@
         }
     ],
     "info": {
-        "_postman_id": "558099ef-bf9f-4522-8e72-3e595acda3c3",
+        "_postman_id": "99d779c7-1fb3-40cd-a800-c8f8634c38cb",
         "name": "Bevragingen ingeschreven personen",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
Verwijderen x-rate-limit headers en overbodige responses 409 (conflict), 410 (gone), 415 (Unsupported Media Type) en 429 (too many requests)

N.a.v. #641