### PR TITLE
feature: redoc als openapi viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@
 
 BRP Bevragen is een Haal Centraal API voor het zoeken en raadplegen van ingeschreven natuurlijke personen voor alle binnengemeentelijke afnemers in NL. De informatie die de API levert is herleidbaar naar het LO GBA 3.10.
 
-# Planning
+## Planning
+
 Release v1.0.0 is uitgebracht en is [hier](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/tree/v1.0.0) te vinden.
 
-https://eu-rm.roadmunk.com/publish/29a13c572a0dfc79f1d0386fc572e15383afe11f
+[Haal Centraal 2020 Alle Domeinen - Timeline View](https://eu-rm.roadmunk.com/publish/29a13c572a0dfc79f1d0386fc572e15383afe11f)
 
 ## Getting started
+
 Om te beginnen met ontwikkelen van de API is de [getting started](./docs/getting-started.md) een goed beginpunt. De API is technisch gespecificeerd in Open API specificaties (zie hieronder bij documentatie).
 
 ## Documentatie
-* [Technische specificaties](./specificatie/genereervariant) (Open API Specificaties en JSON schema) en in [Swagger-formaat](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/master/specificatie/genereervariant/openapi.yaml)
+
+* [Technische specificaties](./specificatie/genereervariant) (Open API Specificaties en JSON schema), in [Swagger-formaat](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/swagger-ui/) en in [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/redoc/)
 * [Productvisie](./docs/productvision.md)
 * [Definition of Ready](./docs/definition_of_ready.md)
 * [Definition of Done](./docs/definition_of_done.md)
@@ -25,18 +28,22 @@ Om te beginnen met ontwikkelen van de API is de [getting started](./docs/getting
 * Ontwerpkeuzes staan in het document [Design decisions](./docs/design_decisions.md)
 
 Naast deze API is er nog een aantal andere aan BRP gerelateerde API's beschikbaar:
+
 * [Historische BRP-gegevens bevragen](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-historie-bevragen)
 * [Reisdocumenten bevragen](https://github.com/VNG-Realisatie/Haal-Centraal-Reisdocumenten-bevragen)
 * [Bewoning en medebewoners bevragen](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bewoning)
 * [Landelijke tabellen bevragen](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-tabellen-bevragen)
 
 ## Bronnen
+
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/)
 
-## Contactpersonen:
+## Contactpersonen
+
 * Product owner: [@CathyDingemanse](https://github.com/CathyDingemanse)
 * Berichtontwerper: [@JohanBoer](https://github.com/JohanBoer)
 
 ## Licentie
+
 Copyright &copy; VNG Realisatie 2018
 Licensed under the [EUPL](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/master/LICENCE.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,21 +3,25 @@
 De 'Bevraging Ingeschreven Persoon' Web API is gespecificeerd met behulp van de OpenAPI specifications (OAS).
 
 Om de API te gebruiken kun je de volgende stappen doorlopen:
+
 1. Bekijk de [functionaliteit en specificaties](#Functionaliteit-en-specificaties)
 2. [Implementeer](#Implementeer-de-API) de API
 3. [Probeer en test](#Probeer-en-test) de API
 
 ## Functionaliteit en specificaties
-Een visuele representatie van de specificatie kan worden gegenereerd met [Swagger UI](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/VNG-Realisatie/Bevragingen-ingeschreven-personen/master/specificatie/genereervariant/openapi.yaml).
+
+Een visuele representatie van de specificatie kan worden gegenereerd met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/swagger-ui/) of [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/redoc/).
 
 De [functionele documentatie](../../../features) van de 'Bevraging Ingeschreven Persoon' Web API is ook te vinden in de github repository.
 
 ## Implementeer de API
+
 Je kunt code genereren op basis van de [genereervariant van de specificaties](../specificatie/genereervariant/openapi.yaml).
 We hebben al voor enkele ontwikkelomgevingen [client code](../../../code) gegenereerd.
 
 ## Probeer en test
-De 'Bevraging Ingeschreven Persoon' Web API is voor proberen en testen te benaderen via de volgende url: https://www.haalcentraal.nl/haalcentraal/api/brp
+
+De 'Bevraging Ingeschreven Persoon' Web API is voor proberen en testen te benaderen via de volgende url: `https://www.haalcentraal.nl/haalcentraal/api/brp`
 
 Om de web api te kunnen bevragen is een apikey nodig. Deze voeg je aan een request toe als header "X-API-KEY". Een API-key kan je aanvragen bij de product owner Cathy Dingemanse, cathy.dingemanse@denhaag.nl.
 
@@ -53,7 +57,7 @@ https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/mast
 4. Kies TYPE "API Key"
 5. Vul in Key: "x-api-key", Value: de API key die je van Cathy hebt ontvangen, Add to: "Header"
 6. Selecteer tabblad "Variables"
-7. Vul bij baseUrl INITIAL VALUE en bij CURRENT VALUE: https://www.haalcentraal.nl/haalcentraal/api/brp
+7. Vul bij baseUrl INITIAL VALUE en bij CURRENT VALUE: `https://www.haalcentraal.nl/haalcentraal/api/brp`
 8. Klik op de knop Update
 
 ### Raadpleeg een Ingeschreven Natuurlijk Persoon

--- a/redoc/index.html
+++ b/redoc/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ReDoc</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='../specificatie/genereervariant/openapi.yaml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>
+


### PR DESCRIPTION
P.R voor de master branch, omdat deze alleen kan worden gebruikt als hij op de master branch staat, zodat github pages het kan oppakken. Als de p.r. is gemerged, dan is de redoc versie te zien op: https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/redoc