### PR TITLE
RvIG docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 API voor het zoeken en raadplegen van actuele personen, partners, ouders en kinderen uit de basisregistratie personen (BRP), inclusief de registratie niet-ingezeten (RNI).
 De API wordt nog niet door RvIG aangeboden. Om de migratie naar API's te versnellen besluiten sommige gemeenten de API zelf aan te bieden.
+RvIG implementeert de API zonder verschillende [afgeleide gegevens](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/rvig_en_proxy). Daarom is er ook een [proxy API](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/rvig_en_proxy) beschikbaar waarmee deze afgeleide gegevens weer kunnen worden toegevoegd.
 
 De laatste versie is 1.3.0. Lees de [release notes](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/releasenotes.html) om te zien wat er gewijzigd is.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 API voor het zoeken en raadplegen van actuele personen, partners, ouders en kinderen uit de basisregistratie personen (BRP), inclusief de registratie niet-ingezeten (RNI).
 De API wordt nog niet door RvIG aangeboden. Om de migratie naar API's te versnellen besluiten sommige gemeenten de API zelf aan te bieden.
-RvIG implementeert de API zonder verschillende [afgeleide gegevens](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/rvig_en_proxy). Daarom is er ook een [proxy API](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/rvig_en_proxy) beschikbaar waarmee deze afgeleide gegevens weer kunnen worden toegevoegd.
+RvIG implementeert de API zonder verschillende [afgeleide gegevens](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/rvig_en_proxy). Daarom wordt er ook een [proxy API](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/rvig_en_proxy) ontwikkeld waarmee deze afgeleide gegevens weer kunnen worden toegevoegd.
 
 De laatste versie is 1.3.0. Lees de [release notes](https://vng-realisatie.github.io/Haal-Centraal-BRP-bevragen/releasenotes.html) om te zien wat er gewijzigd is.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ title: Haal Centraal BRP bevragen
 
 API voor het zoeken en raadplegen van actuele personen, partners, ouders en kinderen uit de basisregistratie personen (BRP), inclusief de registratie niet-ingezeten (RNI).
 De API wordt nog niet door RvIG aangeboden. Om de migratie naar API's te versnellen besluiten sommige gemeenten de API zelf aan te bieden.
+RvIG implementeert de API zonder verschillende [afgeleide gegevens](rvig_en_proxy). Daarom is er ook een [proxy API](rvig_en_proxy) beschikbaar waarmee deze afgeleide gegevens weer kunnen worden toegevoegd.
 
 De laatste versie is 1.3.0. Lees de [release notes](releasenotes.md) om te zien wat er gewijzigd is.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ title: Haal Centraal BRP bevragen
 
 API voor het zoeken en raadplegen van actuele personen, partners, ouders en kinderen uit de basisregistratie personen (BRP), inclusief de registratie niet-ingezeten (RNI).
 De API wordt nog niet door RvIG aangeboden. Om de migratie naar API's te versnellen besluiten sommige gemeenten de API zelf aan te bieden.
-RvIG implementeert de API zonder verschillende [afgeleide gegevens](rvig_en_proxy). Daarom is er ook een [proxy API](rvig_en_proxy) beschikbaar waarmee deze afgeleide gegevens weer kunnen worden toegevoegd.
+RvIG implementeert de API zonder verschillende [afgeleide gegevens](rvig_en_proxy). Daarom wordt er ook een [proxy API](rvig_en_proxy) ontwikkeld waarmee deze afgeleide gegevens weer kunnen worden toegevoegd.
 
 De laatste versie is 1.3.0. Lees de [release notes](releasenotes.md) om te zien wat er gewijzigd is.
 

--- a/docs/rvig_en_proxy.md
+++ b/docs/rvig_en_proxy.md
@@ -1,0 +1,35 @@
+---
+layout: page-with-side-nav
+title: RvIG API en Proxy API
+---
+
+# RvIG API en Proxy API
+
+In de implementatie van de BRP-bevragen API door RvIG zullen niet alle gegevens die zijn gedefinieerd in versie 2.0.0 van de API worden geleverd. Dit betreft afgeleide gegevens die om juridische redenen nog niet geleverd mogen worden.
+
+Er wordt daarom een proxy API ter beschikking gesteld die tussen een client en de door RvIG geleverde API zal worden gepositioneerd en deze afgeleide gegevens zal toevoegen.
+
+## Gegevens die niet geleverd worden
+
+Het betreft de volgende gegevens die niet door de RvIG API geleverd zullen worden:
+  - IngeschrevenPersoon:
+    - naam.aanhef
+    - naam.aanschrijfwijze
+    - naam.regelVoorafgaandAanAanschrijfwijze
+    - naam.gebruikInLopendeTekst
+    - naam.voorletters
+    - leeftijd
+    - ouders.naam.voorletters
+    - partners.naam.voorletters
+    - kinderen.naam.voorletters
+    - kinderen.leeftijd
+
+## Proxy API
+Er wordt een proxy API ter beschikking gesteld als Docker container. Deze draait u lokaal en zal door de API clients worden aangesproken.
+
+De proxy API werkt in grote lijnen zo:
+1. Een client stuurt een request naar de BRP-bevragen API van de proxy API.
+2. De proxy API stuurt het request door naar de BRP-bevragen API bij RvIG.
+3. De proxy voegt aan het antwoord van de BRP-bevragen API van RvIG de afgeleide gegevens toe op basis van de gegevens in dat antwoord.
+4. De proxy retourneert het antwoord inclusief afgeleide gegevens aan de client.
+

--- a/docs/rvig_en_proxy.md
+++ b/docs/rvig_en_proxy.md
@@ -5,9 +5,9 @@ title: RvIG API en Proxy API
 
 # RvIG API en Proxy API
 
-In de implementatie van de BRP-bevragen API door RvIG zullen niet alle gegevens die zijn gedefinieerd in versie 2.0.0 van de API worden geleverd. Dit betreft afgeleide gegevens die om juridische redenen nog niet geleverd mogen worden.
+In de implementatie van de BRP-bevragen API door RvIG zullen niet alle gegevens die zijn gedefinieerd worden geleverd. Dit betreft afgeleide gegevens die om juridische redenen nog niet door RvIG geleverd mogen worden.
 
-Er wordt daarom een proxy API ter beschikking gesteld die tussen een client en de door RvIG geleverde API zal worden gepositioneerd en deze afgeleide gegevens zal toevoegen.
+Er wordt daarom een proxy API ontwikkeld die tussen een client en de door RvIG geleverde API zal worden gepositioneerd en deze afgeleide gegevens zal toevoegen.
 
 ## Gegevens die niet geleverd worden
 
@@ -25,7 +25,7 @@ Het betreft de volgende gegevens die niet door de RvIG API geleverd zullen worde
     - kinderen.leeftijd
 
 ## Proxy API
-Er wordt een proxy API ter beschikking gesteld als Docker container. Deze draait u lokaal en zal door de API clients worden aangesproken.
+Er wordt een proxy API ontwikkeld die ter beschikking zal worden gesteld als Docker container. Deze draait u lokaal en zal door de API clients worden aangesproken.
 
 De proxy API werkt in grote lijnen zo:
 1. Een client stuurt een request naar de BRP-bevragen API van de proxy API.


### PR DESCRIPTION
uitleg van welke gegevens niet in de RvIG implementatie zitten en dat er een proxy API wordt ontwikkeld.

t.z.t. (wanneer de RvIG API en de proxy API beschikbaar zijn moet de tekst weer worden aangepast. Dan zal er ook een getting started voor de proxy api moeten worden gemaakt