### PR TITLE
Feature/query params scherper

### DIFF
--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -67,6 +67,7 @@ paths:
           description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)"
           schema:
             type: string
+            pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
         - in: query
           name: burgerservicenummer
           required: false
@@ -78,11 +79,8 @@ paths:
             type: array
             items:
               type: string
-              pattern: "^[0-9]*$"
-              maxLength: 9
-              minLength: 9
+              pattern: "^[0-9]9$"
         - in: query
-# Je zou kunnen nadenken over een aanvullende validatie op minimum waarde( bv voor 1900) en maximum waarde (datum niet later dan morgen)
           name: geboorte__datum
           description: |
                         Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
@@ -92,15 +90,13 @@ paths:
             format: date
             example: "1964-09-24"
         - in: query
-# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: geboorte__plaats
           description: |
                         Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           required: false
           schema:
             type: string
-            maxLength: 40
-#           minLength: 3 ?????
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,40}(\?+|\*)?$
             example: "Utrecht"
         - in: query
           name: geslachtsaanduiding
@@ -118,35 +114,31 @@ paths:
             type: boolean
             example: true
         - in: query
-# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: naam__geslachtsnaam
           description: |
                         De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           required: false
           schema:
             type: string
-            maxLength: 200
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
             example: "Vries"
         - in: query
-# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: naam__voorvoegsel
           description: |
                         Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           required: false
           schema:
             type: string
-            maxLength: 10
+            pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
             example: "de"
         - in: query
-# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: naam__voornamen
           description: |
                         De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           required: false
           schema:
             type: string
-            maxLength: 200
-#           minLength: 3   ???
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
             example: "Dirk"
         - in: query
           name: verblijfplaats__gemeenteVanInschrijving
@@ -155,8 +147,7 @@ paths:
           required: false
           schema:
             type: string
-            maxLength: 4
-            minLength: 4
+            pattern: "^[0-9]{4}$"
             example: "0518"
         - in: query
           name: verblijfplaats__huisletter
@@ -165,8 +156,7 @@ paths:
           required: false
           schema:
             type: string
-            maxLength: 1
-            minLength: 1
+            pattern: "^[a-zA-Z]{1}$"
             example: "a"
         - in: query
           name: verblijfplaats__huisnummer
@@ -175,19 +165,16 @@ paths:
           required: false
           schema:
             type: integer
-            maximum: 99999
-            minimum: 1    # Of 0 ?? In ieder geval sluiten we hiermee negatieve huisnummers uit.
+            pattern: "^[0-9]{1,5}$"
             example: 14
         - in: query
-#  Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: verblijfplaats__huisnummertoevoeging
           description: |
                         Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
           required: false
           schema:
             type: string
-            maxLength: 4
-            pattern: "^[0-9]{9}$" #Pattern strakker gedefinieerd.
+            pattern: "^[a-zA-Z0-9]{1,4}$"
             example: "bis"
         - in: query
           name: verblijfplaats__nummeraanduidingIdentificatie
@@ -197,8 +184,6 @@ paths:
           schema:
             type: string
             pattern: "^[0-9]{16}$"
-            maxLength: 16
-            minLength: 16
             example: "0518200000366054"
         - in: query
           name: verblijfplaats__straat
@@ -207,7 +192,7 @@ paths:
           required: false
           schema:
             type: string
-            maxLength: 80
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,80}(\?+|\*)?$
             example: "Tulpstraat"
         - in: query
           name: verblijfplaats__postcode
@@ -216,7 +201,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$ # Accepteren we een spatie in de postcode ook bij het zoeken ? Daar heb ik nu de reguliere expressie op aangepast.
+            pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$
             example: "2341SX"
       responses:
         '200':
@@ -295,7 +280,7 @@ paths:
             schema:
                 $ref: '#/components/schemas/IngeschrevenPersoonQuery'
       responses:
-        '200':            #is de responsecode hier 200 (Volgens mij is een 201 hier niet op zijn plaats)
+        '200':
           description: |
                         Zoekactie geslaagd
           headers:
@@ -381,23 +366,7 @@ components:
       schema:
         type: "string"
         pattern: "^[0-9]{9}$"
-        maxLength: 9
-        minLength: 9
         example: "555555021"
-    burgerservicenummers:
-      name: burgerservicenummer
-      in: path
-      description: |
-                    Uniek persoonsnummer
-      required: true
-      example: [999993653,999991723,999995078]
-      schema:
-        type: "array"
-        items:
-          type: "string"
-          pattern: "^[0-9]{9}$"
-          maxLength: 9
-          minLength: 9
   schemas:
     IngeschrevenPersoonQuery:
       type: "object"
@@ -406,21 +375,22 @@ components:
       properties:
         fields:
           type: string
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)"
+          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
         burgerservicenummer:
-          $ref: "#/components/parameters/burgerservicenummers"
-        geboorte__datum:    #Twijfel of ik de dubbele underscores moet handhaven.   Ook hier de vraag of er een minimum en eenmaximum datum moetworden afgedwongen
+          $ref: "#/components/schemas/Burgerservicenummers"
+        geboorte__datum:
           description: |
                         Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
 
           type: "string"
           format: date
           example: "1964-09-24"
-        geboorte__plaats:           #Twijfel of ik de dubbele underscores moet handhaven.  Pattern toevoegen of eventueel een feature waarmee beshreven wordt hoe tekst-parameters gvalideerd moeten worden (Code?  specialecharacters)
+        geboorte__plaats:
           description: |
                         Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
-          maxLength: 40
-#         minLength: 3 ???
+          pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,40}(\?+|\*)?$
           example: "Utrecht"
         geslachtsaanduiding:
           $ref: "#/components/schemas/Geslacht_enum"
@@ -429,82 +399,79 @@ components:
                         Als je ook overleden personen in het antwoord wilt, geef dan de parameter inclusiefOverledenPersonen op met waarde True.  Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/overleden_personen.feature)
           type: boolean
           example: true
-        naam__geslachtsnaam:      #Twijfel of ik de dubbele underscores moet handhaven.    Pattern check of feature ?
+        naam__geslachtsnaam:
           description: |
                         De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
-          maxLength: 200
-#         minLength: 3   ???
+          pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
           example: "Vries"
-        naam__voorvoegsel:      #Twijfel of ik de dubbele underscores moet handhaven.    Pattern check of feature ?
+        naam__voorvoegsel:
           description: |
                         Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
-          maxLength: 10
+          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
           example: "de"
-        naam__voornamen:        #Twijfel of ik de dubbele underscores moet handhaven.   Pattern check of feature ?
+        naam__voornamen:
           description: |
                         De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
-          maxLength: 200
-#         minLength: 3  ?????
+          pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
           example: "Dirk"
-        verblijfplaats__gemeenteVanInschrijving:  #Twijfel of ik de dubbele underscores moet handhaven.   Pattern check of feature ?
+        verblijfplaats__gemeenteVanInschrijving:
           description: |
                         Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
           type: string
           pattern: "^[0-9]{4}$"
-          maxLength: 4
-          minLength: 4
           example: "0518"
-        verblijfplaats__huisletter:   #Twijfel of ik de dubbele underscores moet handhaven.
+        verblijfplaats__huisletter:
           description: |
                         Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
           type: string
           pattern: ^[a-zA-Z]{1}$
-          maxLength: 1
-          minLength: 1
           example: "a"
         verblijfplaats__huisnummer:
           description: |
                         Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
           type: integer
-          maximum: 99999
-          minimum: 1    # Of 0 in ieder geval niet negatief.
+          pattern: "^[0-9]{1,5}$"
           example: 14
         verblijfplaats__huisnummertoevoeging:
           description: |
                         Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
           type: string
-          maxLength: 4
-#         pattern ???
+          pattern: "^[a-zA-Z0-9]{1,4}$"
           example: "bis"
-        verblijfplaats__nummeraanduidingIdentificatie:   #Twijfel of ik de dubbele underscores moet handhaven.
+        verblijfplaats__nummeraanduidingIdentificatie:
           description: |
                         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
           type: string
           pattern: "^[0-9]{16}$"
-          maxLength: 16
-          minLength: 16
           example: "0518200000366054"
-        verblijfplaats__straat:       #Twijfel of ik de dubbele underscores moet handhaven.   Pattern check of feature ?
+        verblijfplaats__straat:
           description: |
                         Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
           type: string
-          maxLength: 80
-#         minLength: 3   ????
+          pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,80}(\?+|\*)?$
           example: "Tulpstraat"
-        verblijfplaats__postcode:     #Twijfel of ik de dubbele underscores moet handhaven.
+        verblijfplaats__postcode:
           description: |
                         De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
           type: string
-          pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$ # Accepteren we een spatie in de postcode ook bij het zoeken ? Daar heb ik nu de reguliere expressie op aangepast.
+          pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$
           example: "2341SX"
     Reisdocumentnummer:
       type: "string"
       description: |
                     Het nummer van het verstrekte Nederlandse reisdocument.
       example: "546376728"
+    Burgerservicenummers:
+      description: |
+                    Uniek persoonsnummer
+      example: [999993653,999991723,999995078]
+      type: "array"
+      items:
+        type: "string"
+        pattern: "^[0-9]{9}$"
     IngeschrevenPersoon:
       type: "object"
       properties:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -381,10 +381,10 @@ components:
       required:
       - fields
       properties:
-        fields:
-          type: string
-          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
-          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
+#        fields:
+#          type: string
+#          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
+#          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
         burgerservicenummer:
           description: |
                         Uniek persoonsnummer

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -79,7 +79,7 @@ paths:
             type: array
             items:
               type: string
-              pattern: ^[0-9]9$
+              pattern: ^[0-9]{9}$
               minItems: 1
         - in: query
           name: geboorte__datum

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -295,7 +295,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/IngeschrevenPersoonHalCollectie'
+                $ref: '#/components/schemas/IngeschrevenPersoonCollectie'
         '400':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
@@ -547,6 +547,20 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/Partner"
+    IngeschrevenPersoonCollectie:
+      type: object
+      properties:
+        _links:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
+        _embedded:
+          $ref: "#/components/schemas/IngeschrevenPersoonCollectieEmbedded"
+    IngeschrevenPersoonCollectieEmbedded:
+      type: object
+      properties:
+        ingeschrevenpersonen:
+          type: array
+          items:
+            $ref: '#/components/schemas/IngeschrevenPersoon'
     IngeschrevenPersoonHalCollectie:
       type: object
       properties:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -67,7 +67,7 @@ paths:
           description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
           schema:
             type: string
-            pattern: ^[a-zA-Z.,]+$
+            pattern: ^[a-zA-Z.,_]+$
         - in: query
           name: burgerservicenummer
           required: false
@@ -80,6 +80,7 @@ paths:
             items:
               type: string
               pattern: ^[0-9]9$
+              minItems: 1
         - in: query
           name: geboorte__datum
           description: |
@@ -96,7 +97,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\'%]{1,40}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,40}(\?+|\*)?$
             example: "Utrecht"
         - in: query
           name: geslachtsaanduiding
@@ -120,7 +121,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\'\%]{1,200}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,200}(\?+|\*)?$
             example: "Vries"
         - in: query
           name: naam__voorvoegsel
@@ -129,7 +130,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^[a-zA-Z0-9À-ÿ\s\-\']{1,10}$
+            pattern: ^[a-zA-Z0-9À-ÿ' '\-\']{1,10}$
             example: "de"
         - in: query
           name: naam__voornamen
@@ -138,7 +139,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\']{1,200}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,200}(\?+|\*)?$
             example: "Dirk"
         - in: query
           name: verblijfplaats__gemeenteVanInschrijving
@@ -193,7 +194,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\']{1,80}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,80}(\?+|\*)?$
             example: "Tulpstraat"
         - in: query
           name: verblijfplaats__postcode
@@ -202,8 +203,10 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^[1-9]{1}[0-9]{3}[\s]{0,1}[A-Z]{2}$
+            pattern: ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$
             example: "2341SX"
+        - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/parameters/page'
+        - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/parameters/pageSize'
       responses:
         '200':
           description: |
@@ -275,14 +278,6 @@ paths:
 
         6.  Adres
             -  verblijfplaats__nummeraanduidingIdentificatie
-      parameters:
-      - in: query
-        name: fields
-        required: true
-        description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
-        schema:
-          type: string
-          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
       requestBody:
         content:
           application/hal+json:
@@ -379,13 +374,13 @@ components:
   schemas:
     IngeschrevenPersoonQuery:
       type: "object"
-#      required:
-#      - fields
+      required:
+      - fields
       properties:
-#        fields:
-#          type: string
-#          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
-#          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
+        fields:
+          type: string
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
+          pattern: ^[a-zA-Z.,_]+$
         burgerservicenummer:
           description: |
                         Uniek persoonsnummer
@@ -394,6 +389,7 @@ components:
           items:
             type: "string"
             pattern: "^[0-9]{9}$"
+            minItems: 1
         geboorte__datum:
           description: |
                         Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
@@ -472,8 +468,18 @@ components:
           description: |
                         De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
           type: string
-          pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$
+          pattern: ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$
           example: "2341SX"
+        page:
+          description: Pagina nummer
+          type: integer
+          minimum: 1
+          default: 1
+        pageSize:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 20
     Reisdocumentnummer:
       type: "string"
       description: |
@@ -545,7 +551,7 @@ components:
       type: object
       properties:
         _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
         _embedded:
           $ref: "#/components/schemas/IngeschrevenPersoonHalCollectieEmbedded"
     IngeschrevenPersoonHalCollectieEmbedded:
@@ -896,7 +902,7 @@ components:
                       * **datumInschrijvingInGemeente**: bij inschrijving op grond van een verhuisaangifte door de burger is dit de aangiftedatum. Bij inschrijving op grond van een geboorteakte is dit de geboortedatum. Bij ambtshalve inschrijving is dit de datum waarop het voornemen van ambtshalve opneming schriftelijk aan de persoon is medegedeeld.
                       * **datumVestigingInNederland** : datum van inschrijving in Nederland.
                       * **landVanWaarIngeschreven** : het land waar de persoon woonde voor (her)vestiging in Nederland.
-                      * **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten."
+                      * **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten.
         properties:
           adresseerbaarObjectIdentificatie:
             type: "string"
@@ -1071,28 +1077,10 @@ components:
       properties:
         self:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        ouders:
-          type: "array"
-          description: |
-                        De ouders van de persoon.
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         reisdocumenten:
           type: "array"
           description: |
                         De reisdocumenten die aan de persoon zijn verstrekt.
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        kinderen:
-          type: "array"
-          description: |
-                        De kinderen van de persoon.
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        partners:
-          type: "array"
-          description: |
-                        De actuele bij de ingeschreven persoon geregistreerde huwelijken en geregistreerd partnerschappen. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         partnerhistorie:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -11,7 +11,7 @@ info:
                 Gegevens die er niet zijn of niet actueel zijn krijg je niet terug. Heeft een persoon bijvoorbeeld geen geldige nationaliteit, en alleen een beëindigd partnerschap, dan krijg je geen gegevens over nationaliteit en partner.
 
                 Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/tree/v1.1.0/features) voor nadere toelichting.
-  version: "1.4.0"
+  version: "2.0.0"
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen
   license:
@@ -61,14 +61,12 @@ paths:
             -  verblijfplaats__nummeraanduidingIdentificatie
 
       parameters:
-        - name: expand
-          deprecated: true
-          in: query
-          required: false
-          description: "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/expand.feature)."
+        - in: query
+          name: fields
+          required: true
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)"
           schema:
             type: string
-        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: burgerservicenummer
           required: false
@@ -84,6 +82,7 @@ paths:
               maxLength: 9
               minLength: 9
         - in: query
+# Je zou kunnen nadenken over een aanvullende validatie op minimum waarde( bv voor 1900) en maximum waarde (datum niet later dan morgen)
           name: geboorte__datum
           description: |
                         Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
@@ -93,6 +92,7 @@ paths:
             format: date
             example: "1964-09-24"
         - in: query
+# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: geboorte__plaats
           description: |
                         Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
@@ -100,6 +100,7 @@ paths:
           schema:
             type: string
             maxLength: 40
+#           minLength: 3 ?????
             example: "Utrecht"
         - in: query
           name: geslachtsaanduiding
@@ -117,6 +118,7 @@ paths:
             type: boolean
             example: true
         - in: query
+# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: naam__geslachtsnaam
           description: |
                         De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
@@ -126,6 +128,7 @@ paths:
             maxLength: 200
             example: "Vries"
         - in: query
+# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: naam__voorvoegsel
           description: |
                         Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
@@ -135,6 +138,7 @@ paths:
             maxLength: 10
             example: "de"
         - in: query
+# Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: naam__voornamen
           description: |
                         De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
@@ -142,6 +146,7 @@ paths:
           schema:
             type: string
             maxLength: 200
+#           minLength: 3   ???
             example: "Dirk"
         - in: query
           name: verblijfplaats__gemeenteVanInschrijving
@@ -151,6 +156,7 @@ paths:
           schema:
             type: string
             maxLength: 4
+            minLength: 4
             example: "0518"
         - in: query
           name: verblijfplaats__huisletter
@@ -160,6 +166,7 @@ paths:
           schema:
             type: string
             maxLength: 1
+            minLength: 1
             example: "a"
         - in: query
           name: verblijfplaats__huisnummer
@@ -169,8 +176,10 @@ paths:
           schema:
             type: integer
             maximum: 99999
+            minimum: 1    # Of 0 ?? In ieder geval sluiten we hiermee negatieve huisnummers uit.
             example: 14
         - in: query
+#  Hier reguliere expressie om speciale tekens of code te voorkomen. Dat zou ook in een feature beschreven kunnen worden. De BAG past dit volgens mij al toe.
           name: verblijfplaats__huisnummertoevoeging
           description: |
                         Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
@@ -178,6 +187,7 @@ paths:
           schema:
             type: string
             maxLength: 4
+            pattern: "^[0-9]{9}$" #Pattern strakker gedefinieerd.
             example: "bis"
         - in: query
           name: verblijfplaats__nummeraanduidingIdentificatie
@@ -186,7 +196,9 @@ paths:
           required: false
           schema:
             type: string
+            pattern: "^[0-9]{16}$"
             maxLength: 16
+            minLength: 16
             example: "0518200000366054"
         - in: query
           name: verblijfplaats__straat
@@ -204,7 +216,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^[1-9]{1}[0-9]{3}[A-Z]{2}$
+            pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$ # Accepteren we een spatie in de postcode ook bij het zoeken ? Daar heb ik nu de reguliere expressie op aangepast.
             example: "2341SX"
       responses:
         '200':
@@ -324,13 +336,6 @@ paths:
 
       parameters:
         - $ref: '#/components/parameters/burgerservicenummer'
-        - name: expand
-          deprecated: true
-          in: query
-          required: false
-          description: "Hiermee kun je opgeven welke gerelateerde resources meegeleverd moeten worden, en hun inhoud naar behoefte aanpassen. Hele resources of enkele properties geef je in de expand parameter kommagescheiden op. Properties die je wil ontvangen geef je op met de resource-naam gevolgd door de property naam, met daartussen een punt. In de definitie van het antwoord kun je bij _embedded zien welke gerelateerde resources meegeleverd kunnen worden. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/expand.feature)."
-          schema:
-            type: string
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
@@ -365,279 +370,6 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
         - Ingeschreven Personen
-  /ingeschrevenpersonen/{burgerservicenummer}/kinderen/{id}:
-    get:
-      deprecated: true
-      operationId: GetKind
-      summary: "Raadpleeg een kind van een persoon"
-      description: |
-                    Raadpleeg een kind van een persoon
-      parameters:
-        - $ref: '#/components/parameters/burgerservicenummer'
-        - in: path
-          name: id
-          description: |
-                        De identificatie van het kind.
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/KindHalBasis'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
-        '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
-        '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
-        '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-        - Ingeschreven Personen
-  /ingeschrevenpersonen/{burgerservicenummer}/kinderen:
-    get:
-      deprecated: true
-      operationId: GetKinderen
-      summary: "Levert de kinderen van een persoon"
-      description: |
-                    Levert de kinderen van een persoon
-      parameters:
-        - $ref: '#/components/parameters/burgerservicenummer'
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/KindHalCollectie'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
-        '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
-        '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
-        '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-        - Ingeschreven Personen
-  /ingeschrevenpersonen/{burgerservicenummer}/ouders/{id}:
-    get:
-      deprecated: true
-      operationId: GetOuder
-      summary: "Raadpleeg een ouder van een persoon"
-      description: |
-                    Raadpleeg een ouder van een persoon
-      parameters:
-        - $ref: '#/components/parameters/burgerservicenummer'
-        - in: path
-          name: id
-          description: |
-                        De identificatie van de ouder.
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/OuderHalBasis'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
-        '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
-        '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
-        '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-        - Ingeschreven Personen
-  /ingeschrevenpersonen/{burgerservicenummer}/ouders:
-    get:
-      deprecated: true
-      operationId: GetOuders
-      summary: "Levert de ouders van een persoon"
-      description: |
-                    Levert de ouders van een persoon
-      parameters:
-        - $ref: '#/components/parameters/burgerservicenummer'
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/OuderHalCollectie'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
-        '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
-        '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
-        '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-        - Ingeschreven Personen
-  /ingeschrevenpersonen/{burgerservicenummer}/partners/{id}:
-    get:
-      deprecated: true
-      operationId: GetPartner
-      summary: "Raadpleeg de partner van een persoon"
-      description: |
-                    Raadpleeg de partner van een persoon
-      parameters:
-        - $ref: '#/components/parameters/burgerservicenummer'
-        - in: path
-          name: id
-          description: |
-                        De identificatie van de partner.
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/PartnerHalBasis'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
-        '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
-        '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
-        '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-        - Ingeschreven Personen
-  /ingeschrevenpersonen/{burgerservicenummer}/partners:
-    get:
-      deprecated: true
-      operationId: GetPartners
-      summary: "Levert de actuele partners van een persoon"
-      description: |
-                    Levert de actuele partners van een persoon. Partners uit beëindigde huwelijken of partnerschappen worden niet geretourneerd
-      parameters:
-        - $ref: '#/components/parameters/burgerservicenummer'
-      responses:
-        '200':
-          description: |
-                        Zoekactie geslaagd
-          headers:
-            api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
-            warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/PartnerHalCollectie'
-        '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
-        '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
-        '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
-        '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
-        '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
-        '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
-        '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
-        '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
-        'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
-      tags:
-        - Ingeschreven Personen
 components:
   parameters:
     burgerservicenummer:
@@ -648,7 +380,7 @@ components:
       required: true
       schema:
         type: "string"
-        pattern: "^[0-9]*$"
+        pattern: "^[0-9]{9}$"
         maxLength: 9
         minLength: 9
         example: "555555021"
@@ -663,7 +395,7 @@ components:
         type: "array"
         items:
           type: "string"
-          pattern: "^[0-9]*$"
+          pattern: "^[0-9]{9}$"
           maxLength: 9
           minLength: 9
   schemas:
@@ -676,18 +408,19 @@ components:
           type: string
         burgerservicenummer:
           $ref: "#/components/parameters/burgerservicenummers"
-        geboorte__datum:    #Twijfel of ik de dubbele underscores moet handhaven.
+        geboorte__datum:    #Twijfel of ik de dubbele underscores moet handhaven.   Ook hier de vraag of er een minimum en eenmaximum datum moetworden afgedwongen
           description: |
                         Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
 
           type: "string"
           format: date
           example: "1964-09-24"
-        geboorte__plaats:           #Twijfel of ik de dubbele underscores moet handhaven.
+        geboorte__plaats:           #Twijfel of ik de dubbele underscores moet handhaven.  Pattern toevoegen of eventueel een feature waarmee beshreven wordt hoe tekst-parameters gvalideerd moeten worden (Code?  specialecharacters)
           description: |
                         Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
           maxLength: 40
+#         minLength: 3 ???
           example: "Utrecht"
         geslachtsaanduiding:
           $ref: "#/components/schemas/Geslacht_enum"
@@ -696,66 +429,76 @@ components:
                         Als je ook overleden personen in het antwoord wilt, geef dan de parameter inclusiefOverledenPersonen op met waarde True.  Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/overleden_personen.feature)
           type: boolean
           example: true
-        naam__geslachtsnaam:      #Twijfel of ik de dubbele underscores moet handhaven.
+        naam__geslachtsnaam:      #Twijfel of ik de dubbele underscores moet handhaven.    Pattern check of feature ?
           description: |
                         De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
           maxLength: 200
+#         minLength: 3   ???
           example: "Vries"
-        naam__voorvoegsel:      #Twijfel of ik de dubbele underscores moet handhaven.
+        naam__voorvoegsel:      #Twijfel of ik de dubbele underscores moet handhaven.    Pattern check of feature ?
           description: |
                         Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
           maxLength: 10
           example: "de"
-        naam__voornamen:        #Twijfel of ik de dubbele underscores moet handhaven.
+        naam__voornamen:        #Twijfel of ik de dubbele underscores moet handhaven.   Pattern check of feature ?
           description: |
                         De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
-
           type: string
           maxLength: 200
+#         minLength: 3  ?????
           example: "Dirk"
-        verblijfplaats__gemeenteVanInschrijving:
+        verblijfplaats__gemeenteVanInschrijving:  #Twijfel of ik de dubbele underscores moet handhaven.   Pattern check of feature ?
           description: |
                         Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
           type: string
+          pattern: "^[0-9]{4}$"
           maxLength: 4
+          minLength: 4
           example: "0518"
-        verblijfplaats__huisletter:
+        verblijfplaats__huisletter:   #Twijfel of ik de dubbele underscores moet handhaven.
           description: |
                         Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
           type: string
+          pattern: ^[a-zA-Z]{1}$
           maxLength: 1
+          minLength: 1
           example: "a"
         verblijfplaats__huisnummer:
           description: |
                         Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
           type: integer
           maximum: 99999
+          minimum: 1    # Of 0 in ieder geval niet negatief.
           example: 14
         verblijfplaats__huisnummertoevoeging:
           description: |
                         Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
           type: string
           maxLength: 4
+#         pattern ???
           example: "bis"
-        verblijfplaats__nummeraanduidingIdentificatie:
+        verblijfplaats__nummeraanduidingIdentificatie:   #Twijfel of ik de dubbele underscores moet handhaven.
           description: |
                         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
           type: string
+          pattern: "^[0-9]{16}$"
           maxLength: 16
+          minLength: 16
           example: "0518200000366054"
-        verblijfplaats__straat:
+        verblijfplaats__straat:       #Twijfel of ik de dubbele underscores moet handhaven.   Pattern check of feature ?
           description: |
                         Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
           type: string
           maxLength: 80
+#         minLength: 3   ????
           example: "Tulpstraat"
-        verblijfplaats__postcode:
+        verblijfplaats__postcode:     #Twijfel of ik de dubbele underscores moet handhaven.
           description: |
                         De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
           type: string
-          pattern: ^[1-9]{1}[0-9]{3}[A-Z]{2}$
+          pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$ # Accepteren we een spatie in de postcode ook bij het zoeken ? Daar heb ik nu de reguliere expressie op aangepast.
           example: "2341SX"
     Reisdocumentnummer:
       type: "string"
@@ -847,9 +590,6 @@ components:
     IngeschrevenPersoonHal:
       allOf:
         - $ref: '#/components/schemas/IngeschrevenPersoonHalBasis'
-        - properties:
-            _embedded:
-              $ref: "#/components/schemas/IngeschrevenPersoonEmbedded"
     Ouder:
       type: "object"
       description: |
@@ -871,34 +611,6 @@ components:
           $ref: "#/components/schemas/OuderInOnderzoek"
         geboorte:
           $ref: "#/components/schemas/Geboorte"
-    OuderHalCollectie:
-      deprecated: true
-      type: object
-      properties:
-        _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
-        _embedded:
-          $ref: '#/components/schemas/OuderHalCollectieEmbedded'
-    OuderHalCollectieEmbedded:
-      deprecated: true
-      type: object
-      properties:
-        ouders:
-          type: array
-          items:
-            $ref: '#/components/schemas/OuderHalBasis'
-    OuderHalBasis:
-      deprecated: true
-      allOf:
-        - $ref: '#/components/schemas/Ouder'
-        - properties:
-            geheimhoudingPersoonsgegevens:
-              type: boolean
-              title: "Indicatie geheim"
-              description: |
-                            Gegevens mogen niet worden verstrekt aan derden / maarschappelijke instellingen.
-            _links:
-              $ref: "#/components/schemas/OuderLinks"
     Kind:
       type: "object"
       description: |
@@ -918,34 +630,6 @@ components:
           $ref: "#/components/schemas/Naam"
         geboorte:
           $ref: "#/components/schemas/Geboorte"
-    KindHalCollectie:
-      deprecated: true
-      type: object
-      properties:
-        _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
-        _embedded:
-          $ref: '#/components/schemas/KindHalCollectieEmbedded'
-    KindHalCollectieEmbedded:
-      deprecated: true
-      type: object
-      properties:
-        kinderen:
-          type: array
-          items:
-            $ref: '#/components/schemas/KindHalBasis'
-    KindHalBasis:
-      deprecated: true
-      allOf:
-        - $ref: '#/components/schemas/Kind'
-        - properties:
-            geheimhoudingPersoonsgegevens:
-              type: boolean
-              title: "Indicatie geheim"
-              description: |
-                            Gegevens mogen niet worden verstrekt aan derden/ maatschappelijke instellingen.
-            _links:
-              $ref: "#/components/schemas/KindLinks"
     Partner:
       type: "object"
       description: |
@@ -966,34 +650,6 @@ components:
           $ref: "#/components/schemas/PartnerInOnderzoek"
         aangaanHuwelijkPartnerschap:
           $ref: "#/components/schemas/AangaanHuwelijkPartnerschap"
-    PartnerHalCollectie:
-      deprecated: true
-      type: object
-      properties:
-        _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
-        _embedded:
-          $ref: '#/components/schemas/PartnerHalCollectieEmbedded'
-    PartnerHalCollectieEmbedded:
-      deprecated: true
-      type: object
-      properties:
-        partners:
-          type: array
-          items:
-            $ref: '#/components/schemas/PartnerHalBasis'
-    PartnerHalBasis:
-      deprecated: true
-      allOf:
-        - $ref: '#/components/schemas/Partner'
-        - properties:
-            geheimhoudingPersoonsgegevens:
-              type: boolean
-              title: "Indicatie geheim"
-              description: |
-                            Gegevens mogen niet worden verstrekt aan derden/ maatschappelijke instellingen.
-            _links:
-              $ref: "#/components/schemas/PartnerLinks"
     Naam:
       type: "object"
       properties:
@@ -1475,52 +1131,6 @@ components:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         adres:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-    OuderLinks:
-      deprecated: true
-      type: "object"
-      properties:
-        self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        ingeschrevenPersoon:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-    KindLinks:
-      deprecated: true
-      type: "object"
-      properties:
-        self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        ingeschrevenPersoon:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-    PartnerLinks:
-      deprecated: true
-      type: "object"
-      properties:
-        self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        ingeschrevenPersoon:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-    IngeschrevenPersoonEmbedded:
-      type: "object"
-      deprecated: true
-      properties:
-        ouders:
-          type: "array"
-          description: |
-                        De ouders van de persoon.
-          items:
-            $ref: "#/components/schemas/OuderHalBasis"
-        kinderen:
-          type: "array"
-          description: |
-                        De kinderen van de persoon.
-          items:
-            $ref: "#/components/schemas/KindHalBasis"
-        partners:
-          type: "array"
-          description: |
-                        De partners van de persoon. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.
-          items:
-            $ref: "#/components/schemas/PartnerHalBasis"
     AanduidingBijzonderNederlanderschap_enum:
       type: "string"
       description: |

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -378,7 +378,13 @@ components:
           description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)"
           pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
         burgerservicenummer:
-          $ref: "#/components/schemas/Burgerservicenummers"
+          description: |
+                        Uniek persoonsnummer
+          example: [999993653,999991723,999995078]
+          type: "array"
+          items:
+            type: "string"
+            pattern: "^[0-9]{9}$"
         geboorte__datum:
           description: |
                         Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
@@ -464,14 +470,6 @@ components:
       description: |
                     Het nummer van het verstrekte Nederlandse reisdocument.
       example: "546376728"
-    Burgerservicenummers:
-      description: |
-                    Uniek persoonsnummer
-      example: [999993653,999991723,999995078]
-      type: "array"
-      items:
-        type: "string"
-        pattern: "^[0-9]{9}$"
     IngeschrevenPersoon:
       type: "object"
       properties:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -666,7 +666,6 @@ components:
           pattern: "^[0-9]*$"
           maxLength: 9
           minLength: 9
-
   schemas:
     IngeschrevenPersoonQuery:
       type: "object"
@@ -733,7 +732,6 @@ components:
                         Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
           type: integer
           maximum: 99999
-          minimum: 1   #strakkere datadefinitie voor parameter (threatmodel). geen negatieven. Vraag Bestaat er ergens een huisnummer 0 ???
           example: 14
         verblijfplaats__huisnummertoevoeging:
           description: |
@@ -746,7 +744,6 @@ components:
                         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
           type: string
           maxLength: 16
-          minLength: 16       #scherpere datadefinitie (threatmodel)
           example: "0518200000366054"
         verblijfplaats__straat:
           description: |

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -550,13 +550,6 @@ components:
     IngeschrevenPersoonCollectie:
       type: object
       properties:
-        _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalPaginationLinks"
-        _embedded:
-          $ref: "#/components/schemas/IngeschrevenPersoonCollectieEmbedded"
-    IngeschrevenPersoonCollectieEmbedded:
-      type: object
-      properties:
         ingeschrevenpersonen:
           type: array
           items:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -29,17 +29,17 @@ paths:
         Default krijg je personen terug die nog in leven zijn, tenzij je de inclusiefoverledenpersonen=true opgeeft.
 
 
-        Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)
+        Het is verplicht om met de fields parameter de gewenste velden in het antwoord te definieren, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)
 
 
         1.  Persoon
             -  geboorte__datum
-            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)
 
 
         2.  Persoon
             -  verblijfplaats__gemeenteVanInschrijving
-            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)
 
 
         3.  Persoon
@@ -52,7 +52,7 @@ paths:
 
 
         5.  Straat
-            -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) )
+            -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) )
             -  verblijfplaats__gemeenteVanInschrijving
             -  verblijfplaats__huisnummer
 
@@ -64,7 +64,7 @@ paths:
         - in: query
           name: fields
           required: true
-          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)"
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
           schema:
             type: string
             pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
@@ -116,7 +116,7 @@ paths:
         - in: query
           name: naam__geslachtsnaam
           description: |
-                        De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+                        De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           required: false
           schema:
             type: string
@@ -134,7 +134,7 @@ paths:
         - in: query
           name: naam__voornamen
           description: |
-                        De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+                        De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           required: false
           schema:
             type: string
@@ -188,7 +188,7 @@ paths:
         - in: query
           name: verblijfplaats__straat
           description: |
-                        Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
+                        Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
           required: false
           schema:
             type: string
@@ -209,29 +209,29 @@ paths:
                         Zoekactie geslaagd
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/warning"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/IngeschrevenPersoonHalCollectie'
         '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/403"
         '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/406"
         '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/501"
         '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
         - Ingeschreven Personen
     post:
@@ -244,17 +244,17 @@ paths:
         Default krijg je personen terug die nog in leven zijn, tenzij je de inclusiefoverledenpersonen=true opgeeft.
 
 
-        Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)
+        Het is verplicht om met de fields parameter de gewenste velden in het antwoord te definieren, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)
 
 
         1.  Persoon
             -  geboorte__datum
-            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)
 
 
         2.  Persoon
             -  verblijfplaats__gemeenteVanInschrijving
-            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)
 
 
         3.  Persoon
@@ -267,13 +267,21 @@ paths:
 
 
         5.  Straat
-            -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) )
+            -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) )
             -  verblijfplaats__gemeenteVanInschrijving
             -  verblijfplaats__huisnummer
 
 
         6.  Adres
             -  verblijfplaats__nummeraanduidingIdentificatie
+      parameters:
+      - in: query
+        name: fields
+        required: true
+        description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
+        schema:
+          type: string
+          pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
       requestBody:
         content:
           application/hal+json:
@@ -285,29 +293,29 @@ paths:
                         Zoekactie geslaagd
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/warning"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/IngeschrevenPersoonHalCollectie'
         '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/403"
         '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/406"
         '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/501"
         '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
         - Ingeschreven Personen
   /ingeschrevenpersonen/{burgerservicenummer}:
@@ -321,38 +329,38 @@ paths:
 
       parameters:
         - $ref: '#/components/parameters/burgerservicenummer'
-        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/fields"
+        - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/parameters/fields"
       responses:
         '200':
           description: |
                         Zoekactie geslaagd
           headers:
             api-version:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/api_version"
             warning:
-              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/warning"
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/IngeschrevenPersoonHal'
         '400':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/400"
         '401':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/401"
         '403':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/403"
         '404':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/404"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/404"
         '406':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/406"
         '500':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/500"
         '501':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/501"
         '503':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/503"
         'default':
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/responses/default"
       tags:
         - Ingeschreven Personen
 components:
@@ -375,7 +383,7 @@ components:
       properties:
         fields:
           type: string
-          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)"
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
           pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
         burgerservicenummer:
           description: |
@@ -407,7 +415,7 @@ components:
           example: true
         naam__geslachtsnaam:
           description: |
-                        De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+                        De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
           pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
           example: "Vries"
@@ -419,7 +427,7 @@ components:
           example: "de"
         naam__voornamen:
           description: |
-                        De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+                        De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
           type: string
           pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
           example: "Dirk"
@@ -455,7 +463,7 @@ components:
           example: "0518200000366054"
         verblijfplaats__straat:
           description: |
-                        Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
+                        Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
           type: string
           pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,80}(\?+|\*)?$
           example: "Tulpstraat"
@@ -493,7 +501,7 @@ components:
                         Leeftijd in jaren op het moment van bevragen.
           example: 34
         datumEersteInschrijvingGBA:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         kiesrecht:
           $ref: "#/components/schemas/Kiesrecht"
         naam:
@@ -536,7 +544,7 @@ components:
       type: object
       properties:
         _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
         _embedded:
           $ref: "#/components/schemas/IngeschrevenPersoonHalCollectieEmbedded"
     IngeschrevenPersoonHalCollectieEmbedded:
@@ -569,7 +577,7 @@ components:
         ouderAanduiding:
           $ref: "#/components/schemas/OuderAanduiding_enum"
         datumIngangFamilierechtelijkeBetrekking:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         naam:
           $ref: "#/components/schemas/Naam"
         inOnderzoek:
@@ -637,7 +645,7 @@ components:
           type: "string"
           example: "de"
         adellijkeTitelPredikaat:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         inOnderzoek:
           $ref: "#/components/schemas/NaamInOnderzoek"
     NaamInOnderzoek:
@@ -654,7 +662,7 @@ components:
         adellijkeTitelPredikaat:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     NaamPersoonInOnderzoek:
       allOf:
         - $ref: '#/components/schemas/NaamInOnderzoek'
@@ -673,7 +681,7 @@ components:
         geslachtsaanduiding:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Geboorte:
       allOf:
       - $ref: '#/components/schemas/Geboortedatum'
@@ -684,9 +692,9 @@ components:
                       * **plaats** : gemeente waar de persoon is geboren. Is de persoon geboren buiten Nederland, dan bevat het antwoord alleen een buitenlandse plaatsnaam of aanduiding.
         properties:
           land:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           plaats:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           inOnderzoek:
             $ref: "#/components/schemas/GeboorteInOnderzoek"
     GeboorteInOnderzoek:
@@ -701,7 +709,7 @@ components:
         plaats:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Kiesrecht:
       type: "object"
       properties:
@@ -714,9 +722,9 @@ components:
           type: boolean
           example: true
         einddatumUitsluitingEuropeesKiesrecht:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         einddatumUitsluitingKiesrecht:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     NaamPersoon:
       allOf:
         - $ref: "#/components/schemas/Naam"
@@ -755,7 +763,7 @@ components:
         geslachtsaanduiding:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Nationaliteit:
       type: "object"
       description: |
@@ -764,11 +772,11 @@ components:
         aanduidingBijzonderNederlanderschap:
           $ref: "#/components/schemas/AanduidingBijzonderNederlanderschap_enum"
         datumIngangGeldigheid:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         nationaliteit:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         redenOpname:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         inOnderzoek:
           $ref: "#/components/schemas/NationaliteitInOnderzoek"
     NationaliteitInOnderzoek:
@@ -783,7 +791,7 @@ components:
         redenOpname:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     OpschortingBijhouding:
       type: "object"
       description: |
@@ -792,7 +800,7 @@ components:
         reden:
           $ref: "#/components/schemas/RedenOpschortingBijhouding_enum"
         datum:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Overlijden:
       type: "object"
       description: |
@@ -806,11 +814,11 @@ components:
           description: |
                         Geeft aan dat iemand is overleden (waarde true), ongeacht of de overlijdensdatum bekend is.
         datum:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         land:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         plaats:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         inOnderzoek:
           $ref: "#/components/schemas/OverlijdenInOnderzoek"
     OverlijdenInOnderzoek:
@@ -825,7 +833,7 @@ components:
         plaats:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     KindInOnderzoek:
       type: "object"
       description: |
@@ -834,7 +842,7 @@ components:
         burgerservicenummer:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     PartnerInOnderzoek:
       type: "object"
       description: |
@@ -847,7 +855,7 @@ components:
         soortVerbintenis:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     AangaanHuwelijkPartnerschap:
       type: "object"
       description: |
@@ -857,11 +865,11 @@ components:
                     * **plaats** : De gemeente waar het huwelijk is voltrokken of het partnerschap is aangegaan. Voor een plaats buiten Nederland bevat het antwoord een buitenlandse plaatsnaam of aanduiding.
       properties:
         datum:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         land:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         plaats:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         inOnderzoek:
           $ref: "#/components/schemas/AangaanHuwelijkPartnerschapInOnderzoek"
     AangaanHuwelijkPartnerschapInOnderzoek:
@@ -876,7 +884,7 @@ components:
         plaats:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Verblijfplaats:
       allOf:
       - $ref : "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BAG-bevragen/v1.1.0/specificatie/openapi.yaml#/components/schemas/Adres"
@@ -922,17 +930,17 @@ components:
                           Geeft aan dat de persoon is teruggekeerd uit een situatie van 'vertrokken onbekend waarheen.'
             example: true
           datumAanvangAdreshouding:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
           datumIngangGeldigheid:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
           datumInschrijvingInGemeente:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
           datumVestigingInNederland:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
           gemeenteVanInschrijving:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           landVanwaarIngeschreven:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           adresregel1:
             type: "string"
             description: |
@@ -955,7 +963,7 @@ components:
             description: |
                           Indicatie dat de ingeschreven persoon is vertrokken naar het buitenland, maar dat niet bekend is waar naar toe.
           land:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           inOnderzoek:
             $ref: "#/components/schemas/VerblijfplaatsInOnderzoek"
     VerblijfplaatsInOnderzoek:
@@ -1002,7 +1010,7 @@ components:
         woonplaats:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Gezagsverhouding:
       type: "object"
       description: |
@@ -1027,7 +1035,7 @@ components:
         indicatieGezagMinderjarige:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Verblijfstitel:
       type: "object"
       description: |
@@ -1037,11 +1045,11 @@ components:
                     * **aanduiding** : Verblijfstiteltabel die aangeeft over welke verblijfsrechtelijke status de persoon beschikt.
       properties:
         aanduiding:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         datumEinde:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         datumIngang:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         inOnderzoek:
           $ref: "#/components/schemas/VerblijfstitelInOnderzoek"
     VerblijfstitelInOnderzoek:
@@ -1056,46 +1064,46 @@ components:
         datumIngang:
           type: boolean
         datumIngangOnderzoek:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     IngeschrevenPersoonLinks:
       type: "object"
       properties:
         self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         ouders:
           type: "array"
           description: |
                         De ouders van de persoon.
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         reisdocumenten:
           type: "array"
           description: |
                         De reisdocumenten die aan de persoon zijn verstrekt.
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         kinderen:
           type: "array"
           description: |
                         De kinderen van de persoon.
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         partners:
           type: "array"
           description: |
                         De actuele bij de ingeschreven persoon geregistreerde huwelijken en geregistreerd partnerschappen. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         partnerhistorie:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         verblijfplaatshistorie:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         verblijfstitelhistorie:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         nationaliteitHistorie:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         adres:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     AanduidingBijzonderNederlanderschap_enum:
       type: "string"
       description: |
@@ -1209,4 +1217,4 @@ components:
                     * **plaats** : De plaats waar de persoon is geboren. Voor een plaats buiten Nederland is gemeentecode=1999 (RNI) en gemeentenaam de buitenlandse plaatsnaam of aanduiding.
       properties:
         datum:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -67,7 +67,7 @@ paths:
           description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven. Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. De fiels parameter is verplicht vanwege dataminimalisatie overwegingen. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/fields.feature)"
           schema:
             type: string
-            pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
+            pattern: ^[a-zA-Z.,]+$
         - in: query
           name: burgerservicenummer
           required: false
@@ -79,7 +79,7 @@ paths:
             type: array
             items:
               type: string
-              pattern: "^[0-9]9$"
+              pattern: ^[0-9]9$
         - in: query
           name: geboorte__datum
           description: |
@@ -96,7 +96,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,40}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\'%]{1,40}(\?+|\*)?$
             example: "Utrecht"
         - in: query
           name: geslachtsaanduiding
@@ -120,7 +120,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\'\%]{1,200}(\?+|\*)?$
             example: "Vries"
         - in: query
           name: naam__voorvoegsel
@@ -129,7 +129,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^[a-zA-Z0-9À-ÿ \-\']+$
+            pattern: ^[a-zA-Z0-9À-ÿ\s\-\']{1,10}$
             example: "de"
         - in: query
           name: naam__voornamen
@@ -138,7 +138,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,200}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\']{1,200}(\?+|\*)?$
             example: "Dirk"
         - in: query
           name: verblijfplaats__gemeenteVanInschrijving
@@ -193,7 +193,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ \-\']{1,80}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ\s\-\']{1,80}(\?+|\*)?$
             example: "Tulpstraat"
         - in: query
           name: verblijfplaats__postcode
@@ -202,7 +202,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^[1-9]{1}[0-9]{3}[ ]{0,1}[A-Z]{2}$
+            pattern: ^[1-9]{1}[0-9]{3}[\s]{0,1}[A-Z]{2}$
             example: "2341SX"
       responses:
         '200':

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -165,7 +165,8 @@ paths:
           required: false
           schema:
             type: integer
-            pattern: "^[0-9]{1,5}$"
+            maximum: 99999
+            minimum: 1
             example: 14
         - in: query
           name: verblijfplaats__huisnummertoevoeging
@@ -378,8 +379,8 @@ components:
   schemas:
     IngeschrevenPersoonQuery:
       type: "object"
-      required:
-      - fields
+#      required:
+#      - fields
       properties:
 #        fields:
 #          type: string

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -11,7 +11,7 @@ info:
                 Gegevens die er niet zijn of niet actueel zijn krijg je niet terug. Heeft een persoon bijvoorbeeld geen geldige nationaliteit, en alleen een beëindigd partnerschap, dan krijg je geen gegevens over nationaliteit en partner.
 
                 Zie de [Functionele documentatie](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/tree/v1.1.0/features) voor nadere toelichting.
-  version: "1.3.0"
+  version: "1.4.0"
   contact:
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen
   license:
@@ -208,6 +208,82 @@ paths:
             example: "2341SX"
       responses:
         '200':
+          description: |
+                        Zoekactie geslaagd
+          headers:
+            api-version:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/api_version"
+            warning:
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/headers/warning"
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/IngeschrevenPersoonHalCollectie'
+        '400':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/400"
+        '401':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/401"
+        '403':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/403"
+        '406':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/406"
+        '500':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/500"
+        '501':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/501"
+        '503':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
+        'default':
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/default"
+      tags:
+        - Ingeschreven Personen
+    post:
+      operationId: PostIngeschrevenPersonen_zoek
+      summary: Vindt personen
+      description: |
+        Zoek personen met één van de onderstaande verplichte combinaties van parameters en vul ze evt. aan met parameters uit de andere combinaties.
+
+
+        Default krijg je personen terug die nog in leven zijn, tenzij je de inclusiefoverledenpersonen=true opgeeft.
+
+
+        Gebruik de fields parameter als je alleen specifieke velden in het antwoord wil zien, [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/fields_extensie.feature)
+
+
+        1.  Persoon
+            -  geboorte__datum
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+
+
+        2.  Persoon
+            -  verblijfplaats__gemeenteVanInschrijving
+            -  naam__geslachtsnaam (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)
+
+
+        3.  Persoon
+            -  burgerservicenummer
+
+
+        4.  Postcode
+            -  verblijfplaats__postcode
+            -  verblijfplaats__huisnummer
+
+
+        5.  Straat
+            -  verblijfplaats__straat (minimaal 2 karakters, [wildcard toegestaan](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) )
+            -  verblijfplaats__gemeenteVanInschrijving
+            -  verblijfplaats__huisnummer
+
+
+        6.  Adres
+            -  verblijfplaats__nummeraanduidingIdentificatie
+      requestBody:
+        content:
+          application/hal+json:
+            schema:
+                $ref: '#/components/schemas/IngeschrevenPersoonQuery'
+      responses:
+        '200':            #is de responsecode hier 200 (Volgens mij is een 201 hier niet op zijn plaats)
           description: |
                         Zoekactie geslaagd
           headers:
@@ -576,7 +652,114 @@ components:
         maxLength: 9
         minLength: 9
         example: "555555021"
+    burgerservicenummers:
+      name: burgerservicenummer
+      in: path
+      description: |
+                    Uniek persoonsnummer
+      required: true
+      example: [999993653,999991723,999995078]
+      schema:
+        type: "array"
+        items:
+          type: "string"
+          pattern: "^[0-9]*$"
+          maxLength: 9
+          minLength: 9
+
   schemas:
+    IngeschrevenPersoonQuery:
+      type: "object"
+      required:
+      - fields
+      properties:
+        fields:
+          type: string
+        burgerservicenummer:
+          $ref: "#/components/parameters/burgerservicenummers"
+        geboorte__datum:    #Twijfel of ik de dubbele underscores moet handhaven.
+          description: |
+                        Je kunt alleen zoeken met een volledig geboortedatum. Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/parametervalidatie.feature)
+
+          type: "string"
+          format: date
+          example: "1964-09-24"
+        geboorte__plaats:           #Twijfel of ik de dubbele underscores moet handhaven.
+          description: |
+                        Gemeentenaam of een buitenlandse plaats of een plaatsbepaling, die aangeeft waar de persoon is geboren. **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+          type: string
+          maxLength: 40
+          example: "Utrecht"
+        geslachtsaanduiding:
+          $ref: "#/components/schemas/Geslacht_enum"
+        inclusiefOverledenPersonen:
+          description: |
+                        Als je ook overleden personen in het antwoord wilt, geef dan de parameter inclusiefOverledenPersonen op met waarde True.  Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/overleden_personen.feature)
+          type: boolean
+          example: true
+        naam__geslachtsnaam:      #Twijfel of ik de dubbele underscores moet handhaven.
+          description: |
+                        De (geslachts)naam waarvan de eventueel aanwezige voorvoegsels zijn afgesplitst. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+          type: string
+          maxLength: 200
+          example: "Vries"
+        naam__voorvoegsel:      #Twijfel of ik de dubbele underscores moet handhaven.
+          description: |
+                        Deel van de geslachtsnaam dat vooraf gaat aan de rest van de geslachtsnaam. Het zoeken op het voorvoegsel is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+          type: string
+          maxLength: 10
+          example: "de"
+        naam__voornamen:        #Twijfel of ik de dubbele underscores moet handhaven.
+          description: |
+                        De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).**
+
+          type: string
+          maxLength: 200
+          example: "Dirk"
+        verblijfplaats__gemeenteVanInschrijving:
+          description: |
+                        Een code die aangeeft in welke gemeente de persoon woont, of de laatste gemeente waar de persoon heeft gewoond, of de gemeente waar de persoon voor het eerst is ingeschreven.
+          type: string
+          maxLength: 4
+          example: "0518"
+        verblijfplaats__huisletter:
+          description: |
+                        Een toevoeging aan een huisnummer in de vorm van een letter die door de gemeente aan een adresseerbaar object is gegeven.
+          type: string
+          maxLength: 1
+          example: "a"
+        verblijfplaats__huisnummer:
+          description: |
+                        Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
+          type: integer
+          maximum: 99999
+          minimum: 1   #strakkere datadefinitie voor parameter (threatmodel). geen negatieven. Vraag Bestaat er ergens een huisnummer 0 ???
+          example: 14
+        verblijfplaats__huisnummertoevoeging:
+          description: |
+                        Een toevoeging aan een huisnummer of een combinatie van huisnummer en huisletter die door de gemeente aan een adresseerbaar object is gegeven.
+          type: string
+          maxLength: 4
+          example: "bis"
+        verblijfplaats__nummeraanduidingIdentificatie:
+          description: |
+                        Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
+          type: string
+          maxLength: 16
+          minLength: 16       #scherpere datadefinitie (threatmodel)
+          example: "0518200000366054"
+        verblijfplaats__straat:
+          description: |
+                        Een naam die door de gemeente aan een openbare ruimte is gegeven. **Gebruik van de wildcard is toegestaan. Zie [feature-beschrijving](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/wildcard.feature)** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/case_insensitive.feature).
+          type: string
+          maxLength: 80
+          example: "Tulpstraat"
+        verblijfplaats__postcode:
+          description: |
+                        De door PostNL vastgestelde code die bij een bepaalde combinatie van een straatnaam en een huisnummer hoort.
+          type: string
+          pattern: ^[1-9]{1}[0-9]{3}[A-Z]{2}$
+          example: "2341SX"
     Reisdocumentnummer:
       type: "string"
       description: |

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -97,7 +97,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,40}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ '\-\']{1,40}(\?+|\*)?$
             example: "Utrecht"
         - in: query
           name: geslachtsaanduiding
@@ -121,7 +121,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,200}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ '\-\']{1,200}(\?+|\*)?$
             example: "Vries"
         - in: query
           name: naam__voorvoegsel
@@ -194,7 +194,7 @@ paths:
           required: false
           schema:
             type: string
-            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ' '\-\']{1,80}(\?+|\*)?$
+            pattern: ^(\?+|\*)?[a-zA-Z0-9À-ÿ '\-\']{1,80}(\?+|\*)?$
             example: "Tulpstraat"
         - in: query
           name: verblijfplaats__postcode
@@ -280,7 +280,7 @@ paths:
             -  verblijfplaats__nummeraanduidingIdentificatie
       requestBody:
         content:
-          application/hal+json:
+          application/json:
             schema:
                 $ref: '#/components/schemas/IngeschrevenPersoonQuery'
       responses:
@@ -293,7 +293,7 @@ paths:
             warning:
               $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/headers/warning"
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/IngeschrevenPersoonCollectie'
         '400':
@@ -444,7 +444,8 @@ components:
           description: |
                         Een nummer dat door de gemeente aan een adresseerbaar object is gegeven.
           type: integer
-          pattern: "^[0-9]{1,5}$"
+          maximum: 99999
+          minimum: 1
           example: 14
         verblijfplaats__huisnummertoevoeging:
           description: |
@@ -550,6 +551,11 @@ components:
     IngeschrevenPersoonCollectie:
       type: object
       properties:
+        pageInfo:
+          currentPage:
+            type: "integer"
+          hasNextPage:
+            type: "boolean"
         ingeschrevenpersonen:
           type: array
           items:


### PR DESCRIPTION
In deze pull request heb ik :

- Een Post operatie toegevoegd voor zoeken. (inclusief requestbody)
- Alle query-parameters voorzien van patterns en maxLength / minLength verwijderd. (@MelvLee Is een pattern op een integer gewenst ? ) 
- Fields parameter verplicht gemaakt
- Verwijzing naar common versie 1.3.0 aangebracht.
- Deprecated elementen verwijderd. 

Aandachtspunten / vragen : 

- Met het gebruikte pattern kan de ingevoerde parameter bij het gebruik van wildcards langer worden van gedefinieerd. De vraagtekens die voor of na een string kunnen worden gezet worden niet meegeteld in het aantal tekens dat de parameter mage bevatten. Volgens mij hoeft dat geen probleem te zijn. 
- De fields parameter bij de POST kan op 2 manieren worden gedaan. Als query-parameter opgeven of als onderdeel van de request body. Bij voorstellen voor de BAG wordt deze als parameter opgegeven. Lijkt mij een goed idee om dit consistent te houden. 
- Er zijn ook verwijzingen naar features. Daarvoor staat het versienr van de release-tag in het pad. Die wijzig ik pas als de release aangemaakt word.

