### PR TITLE
Enumeraties vervangen door waardelijsten

### DIFF
--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -107,7 +107,7 @@ paths:
                         Geeft aan dat de persoon een man of een vrouw is, of dat het geslacht (nog) onbekend is.
           required: false
           schema:
-              $ref: "#/components/schemas/Geslacht_enum"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         - in: query
           name: inclusiefOverledenPersonen
           description: |
@@ -598,7 +598,7 @@ components:
           description: |
                         Gegevens mogen niet worden verstrekt aan derden / maatschappelijke instellingen.
         geslachtsaanduiding:
-          $ref: "#/components/schemas/Geslacht_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         leeftijd:
           type: integer
           description: |
@@ -680,9 +680,9 @@ components:
           type: "string"
           example: "555555021"
         geslachtsaanduiding:
-          $ref: "#/components/schemas/Geslacht_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         ouderAanduiding:
-          $ref: "#/components/schemas/OuderAanduiding_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         datumIngangFamilierechtelijkeBetrekking:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         naam:
@@ -775,9 +775,9 @@ components:
           type: "string"
           example: "555555021"
         geslachtsaanduiding:
-          $ref: "#/components/schemas/Geslacht_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         soortVerbintenis:
-          $ref: "#/components/schemas/SoortVerbintenis_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         naam:
           $ref: "#/components/schemas/Naam"
         geboorte:
@@ -945,7 +945,7 @@ components:
                             Naam van persoon die je kunt gebruiken als je in lopende tekst (bijvoorbeeld in een brief) aan persoon refereert.
               example: "baron Van den Aedel"
             aanduidingNaamgebruik:
-              $ref: "#/components/schemas/Naamgebruik_enum"
+              $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
             inOnderzoek:
               $ref: "#/components/schemas/NaamPersoonInOnderzoek"
     PersoonInOnderzoek:
@@ -965,7 +965,7 @@ components:
                     * **redenOpname** : De reden op grond waarvan de persoon de nationaliteit gekregen heeft.
       properties:
         aanduidingBijzonderNederlanderschap:
-          $ref: "#/components/schemas/AanduidingBijzonderNederlanderschap_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         datumIngangGeldigheid:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
         nationaliteit:
@@ -993,7 +993,7 @@ components:
                     * **datum**: de datum waarop de bijhouding van de persoonsgegevens is gestaakt.
       properties:
         reden:
-          $ref: "#/components/schemas/RedenOpschortingBijhouding_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         datum:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
     Overlijden:
@@ -1098,14 +1098,14 @@ components:
                           De verblijfplaats van de persoon kan een ligplaats, een standplaats of een verblijfsobject zijn.
             example: "0226010000038820"
           aanduidingBijHuisnummer:
-            $ref: "#/components/schemas/AanduidingBijHuisnummer_enum"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           nummeraanduidingIdentificatie:
             type: "string"
             description: |
                           Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
             example: "0518200000366054"
           functieAdres:
-            $ref: "#/components/schemas/SoortAdres_enum"
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
           indicatieVestigingVanuitBuitenland:
             type: boolean
             description: |
@@ -1217,7 +1217,7 @@ components:
                         Geeft aan dat de persoon onder curatele is gesteld.
           example: true
         indicatieGezagMinderjarige:
-          $ref: "#/components/schemas/IndicatieGezagMinderjarige_enum"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/Waardetabel"
         inOnderzoek:
           $ref: "#/components/schemas/GezagsverhoudingInOnderzoek"
     GezagsverhoudingInOnderzoek:
@@ -1345,110 +1345,106 @@ components:
                         De partners van de persoon. Een beëindigd huwelijk of geregistreerd partnerschap wordt niet teruggegeven.
           items:
             $ref: "#/components/schemas/PartnerHalBasis"
-    AanduidingBijzonderNederlanderschap_enum:
-      type: "string"
-      description: |
-                    Geeft aan dat de persoon behandeld wordt als Nederlander, of dat door de rechter is vastgesteld dat de persoon niet de Nederlandse nationaliteit bezit
-                    * `behandeld_als_nederlander` - B
-                    * `vastgesteld_niet_nederlander` - V
-      enum:
-      - "behandeld_als_nederlander"
-      - "vastgesteld_niet_nederlander"
-    AanduidingBijHuisnummer_enum:
-      type: "string"
-      description: |
-                    De aanduiding die wordt gebruikt voor adressen die geen straatnaam en huisnummeraanduidingen hebben
-                    * `tegenover` - to
-                    * `bij` - by
-      enum:
-      - "tegenover"
-      - "bij"
-    Geslacht_enum:
-      type: "string"
-      description: |
-                    Geeft aan dat de persoon een man of vrouw is, of dat het geslacht (nog) onbekend is
-                    * `man` - M
-                    * `vrouw` - V
-                    * `onbekend` - O
-      enum:
-      - "man"
-      - "vrouw"
-      - "onbekend"
-    IndicatieGezagMinderjarige_enum:
-      type: "string"
-      description: |
-                    Geeft aan wie het gezag heeft over de minderjarige persoon.
-                    * `ouder1` - 1
-                    * `ouder2` - 2
-                    * `derden` - D
-                    * `ouder1_en_derde` - 1D
-                    * `ouder2_en_derde` - 2D
-                    * `ouder1_en_ouder2` - 12
-      enum:
-      - "ouder1"
-      - "ouder2"
-      - "derden"
-      - "ouder1_en_derde"
-      - "ouder2_en_derde"
-      - "ouder1_en_ouder2"
-    Naamgebruik_enum:
-      type: "string"
-      description: |
-                    De manier waarop de geslachtsnaam van persoon en partner van persoon moet worden verwerkt in de manier waarop persoon wil worden aangesproken
-                    * `eigen` - E - gebruik alleen de eigen naam
-                    * `eigen_partner` - N - gebruik de eigen naam voor de partnernaam
-                    * `partner` - P gebruik alleen de partnernaam
-                    * `partner_eigen` - V - gebruik de partnernaam voor de eigen naam.
-
-
-                    De aanduiding naamgebruik is verwerkt in Aanhef, Aanschrijfwijze en gebruikInLopendeTekst."
-      enum:
-      - "eigen"
-      - "eigen_partner"
-      - "partner"
-      - "partner_eigen"
-    OuderAanduiding_enum:
-      type: "string"
-      description: |
-                    Geeft aan om welke ouder het gaat volgens de BRP
-                    * `ouder1` - 1
-                    * `ouder2` - 2
-      enum:
-      - "ouder1"
-      - "ouder2"
-    RedenOpschortingBijhouding_enum:
-      type: "string"
-      description: |
-                    Redenen voor opschorting van de bijhouding
-                    * `overlijden` - O
-                    * `emigratie` - E
-                    * `ministerieel_besluit` - M
-                    * `pl_aangelegd_in_de_rni` - R - opgeschort omdat persoon is ingeschreven in het Register Niet Ingezeten (RNI).
-                    * `fout` - F
-      enum:
-      - "overlijden"
-      - "emigratie"
-      - "ministerieel_besluit"
-      - "pl_aangelegd_in_de_rni"
-      - "fout"
-    SoortAdres_enum:
-      type: "string"
-      description: |
-                    Aanduiding van het soort adres
-                    * `woonadres` - W - adres waar de persoon woont
-                    * `briefadres` - B - het adres van een andere persoon of van een instelling (de zogenoemde briefadresgever). Met dit adres van de briefadresgever is de persoon zonder woonadres toch bereikbaar voor de overheid.
-      enum:
-      - "woonadres"
-      - "briefadres"
-    SoortVerbintenis_enum:
-      type: "string"
-      description: |
-                    Soort verbintenis die bij de burgerlijke stand is ingeschreven
-                    * `huwelijk` - H
-                    * `geregistreerd_partnerschap` - P
-      enum:
-      - "huwelijk"
-      - "geregistreerd_partnerschap"
+#    AanduidingBijzonderNederlanderschap_enum:
+#      type: "string"
+#      description: |
+#                    Geeft aan dat de persoon behandeld wordt als Nederlander, of dat door de rechter is vastgesteld dat de persoon niet de Nederlandse nationaliteit bezit
+#                    * `behandeld_als_nederlander` - B
+#                    * `vastgesteld_niet_nederlander` - V
+#      enum:
+#      - "vastgesteld_niet_nederlander"
+#    AanduidingBijHuisnummer_enum:
+#      type: "string"
+#      description: |
+#                    De aanduiding die wordt gebruikt voor adressen die geen straatnaam en huisnummeraanduidingen hebben
+#                    * `tegenover` - to
+#                    * `bij` - by
+#      enum:
+#      - "tegenover"
+#      - "bij"
+#    Geslacht_enum:
+#      type: "string"
+#      description: |
+#                    Geeft aan dat de persoon een man of vrouw is, of dat het geslacht (nog) onbekend is
+#                    * `man` - M
+#                    * `vrouw` - V
+#                    * `onbekend` - O
+#      enum:
+#      - "man"
+#      - "vrouw"
+#      - "onbekend"
+#   IndicatieGezagMinderjarige_enum:
+#      description: |
+#                    Geeft aan wie het gezag heeft over de minderjarige persoon.
+#                    * `ouder1` - 1
+#                    * `ouder2` - 2
+#                    * `derden` - D
+#                    * `ouder1_en_derde` - 1D
+#                    * `ouder2_en_derde` - 2D
+#                    * `ouder1_en_ouder2` - 12
+#      - "ouder1"
+#      - "ouder2"
+#      - "derden"
+#      - "ouder1_en_derde"
+#      - "ouder2_en_derde"
+#      - "ouder1_en_ouder2"
+#    Naamgebruik_enum:
+#      type: "string"
+#      description: |
+#                    De manier waarop de geslachtsnaam van persoon en partner van persoon moet worden verwerkt in de manier waarop persoon wil worden aangesproken
+#                    * `eigen` - E - gebruik alleen de eigen naam
+#                    * `eigen_partner` - N - gebruik de eigen naam voor de partnernaam
+#                    * `partner` - P gebruik alleen de partnernaam
+#                    * `partner_eigen` - V - gebruik de partnernaam voor de eigen naam.
+#
+#                    De aanduiding naamgebruik is verwerkt in Aanhef, Aanschrijfwijze en gebruikInLopendeTekst."
+#      enum:
+#      - "eigen"
+#      - "eigen_partner"
+#      - "partner"
+#      - "partner_eigen"
+#    OuderAanduiding_enum:
+#      type: "string"
+#      description: |
+#                    Geeft aan om welke ouder het gaat volgens de BRP
+#                    * `ouder1` - 1
+#                    * `ouder2` - 2
+#      enum:
+#      - "ouder1"
+#      - "ouder2"
+#    RedenOpschortingBijhouding_enum:
+#      type: "string"
+#      description: |
+#                    Redenen voor opschorting van de bijhouding
+#                    * `overlijden` - O
+#                    * `emigratie` - E
+#                    * `ministerieel_besluit` - M
+#                    * `pl_aangelegd_in_de_rni` - R - opgeschort omdat persoon is ingeschreven in het Register Niet Ingezeten (RNI).
+#                    * `fout` - F
+#      enum:
+#      - "overlijden"
+#      - "emigratie"
+#      - "ministerieel_besluit"
+#      - "pl_aangelegd_in_de_rni"
+#      - "fout"
+#    SoortAdres_enum:
+#      type: "string"
+#      description: |
+#                    Aanduiding van het soort adres
+#                    * `woonadres` - W - adres waar de persoon woont
+#                    * `briefadres` - B - het adres van een andere persoon of van een instelling (de zogenoemde briefadresgever). Met dit adres van de briefadresgever is de persoon zonder woonadres toch bereikbaar voor de overheid.
+#      enum:
+#      - "woonadres"
+#      - "briefadres"
+#    SoortVerbintenis_enum:
+#      type: "string"
+#      description: |
+#                    Soort verbintenis die bij de burgerlijke stand is ingeschreven
+#                    * `huwelijk` - H
+#                    * `geregistreerd_partnerschap` - P
+#      enum:
+#      - "huwelijk"
+#      - "geregistreerd_partnerschap"
     Geboortedatum:
       type: "object"
       description: |


### PR DESCRIPTION
Hier zijn nog enkele punten open voor discussie : 

- In de API-spec van Haal-Centraal-BRP-tabellen-bevragen staat nu in de omschrijvingen een verwijzing naar de landelijke tabellen. 
Die moet in mijn beleving aangepast worden omdat we nu ook waardetabellen gaan opnemen die geen landelijke tabel zijn. 

- Daarnaast moet ergens beschreven worden welke waardetabellen er moeten worden toegevoegd n.a.v. het vervangen van de enumeraties. Er kan niet verwezen worden naar de inhoud van de landelijke tabellen. Maken we daar een feature voor ? En komt die feature dan bij BRP-bevragen ? 

- Er wordt in een query-parameter gebruik gemaakt van een enumeratie t.b.v. input-validatie (geslachtsaanduiding bij /ingeschreven personen.  Ik heb daar een ref naar de waardetabel neergezet, maar ik twijfel of op die manier inputvalidatie te realiseren is (@Melvlee : daar kan jij vast iets over zeggen.)