### PR TITLE
toevoegen ouderAanduiding aan OnbekendOuder

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -2171,6 +2171,9 @@
         }, {
           "type" : "object",
           "properties" : {
+            "ouderAanduiding" : {
+              "$ref" : "#/components/schemas/Waardetabel"
+            },
             "indicatieOnbekend" : {
               "type" : "boolean",
               "default" : false

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -1640,6 +1640,8 @@ components:
       - $ref: '#/components/schemas/AbstractOuder'
       - type: object
         properties:
+          ouderAanduiding:
+            $ref: '#/components/schemas/Waardetabel'
           indicatieOnbekend:
             type: boolean
             default: false

--- a/specificatie/ouder.yaml
+++ b/specificatie/ouder.yaml
@@ -69,6 +69,8 @@ components:
         - $ref: '#/components/schemas/AbstractOuder'
         - type: object
           properties:
+            ouderAanduiding:
+              $ref: 'common.yaml#/components/schemas/Waardetabel'
             indicatieOnbekend:
               type: boolean
               default: false


### PR DESCRIPTION
ik had hier eerder een opmerking over gemaakt, maar die is blijkbaar verloren gegaan in het proces.

een ouder heeft per definitie altijd een ouderAanduiding (ouder1 of ouder2). Kan dus ook in OnbekendOuder worden opgenomen.