### PR TITLE
herschrijven onbekend waardes feature

### DIFF
--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -55,9 +55,7 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     En de persoon heeft een partner met de volgende gegevens
     | naam                        | waarde             |
     | burgerservicenummer         | 999992935          |
-    En de partner met burgerservicenummer '999992935' heeft de volgende soortVerbintenis gegevens
-    | naam        | waarde   |
-    | code        | .        |
+    | soort verbintenis (15.10)   | .                  |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                                                                     |
     | type                | RaadpleegMetBurgerservicenummer                                            |

--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -35,9 +35,9 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     | type                | RaadpleegMetBurgerservicenummer    |
     | burgerservicenummer | 999992934                          |
     | fields              | burgerservicenummer,<groep>.<veld> |
-    Dan bevat de persoon met burgerservicenummer '999992934' alleen de volgende gegevens
-    | naam                  | waarde    |
-    | burgerservicenummer   | 999992934 |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende '<groep>' gegevens NIET
+    | naam   | 
+    | <veld> |
 
     Voorbeelden:
     | groep          | veld                              | waarde           |
@@ -55,7 +55,7 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     En de persoon heeft een partner met de volgende gegevens
     | naam                        | waarde             |
     | burgerservicenummer         | 999992935          |
-    En de <relatie> met burgerservicenummer '999992935' heeft de volgende soortVerbintenis gegevens
+    En de partner met burgerservicenummer '999992935' heeft de volgende soortVerbintenis gegevens
     | naam        | waarde   |
     | code        | .        |
     Als personen wordt gezocht met de volgende parameters

--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -29,8 +29,8 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     | naam                | waarde     |
     | burgerservicenummer | 999992934  |
     En de persoon heeft de volgende <groep> gegevens
-    | naam   | waarde   |
-    | <veld> | <waarde> |
+    | naam               | waarde   |
+    | <veld> (<element>) | <waarde> |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                             |
     | type                | RaadpleegMetBurgerservicenummer    |
@@ -41,13 +41,13 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     | <veld> |
 
     Voorbeelden:
-    | groep          | veld                              | waarde           |
-    | naam           | geslachtsnaam                     | .                |
-    | verblijfplaats | straat                            | .                |
-    | verblijfplaats | huisnummer                        | 0                |
-    | verblijfplaats | woonplaats                        | .                |
-    | verblijfplaats | nummeraanduidingIdentificatie     | 0000000000000000 |
-    | verblijfplaats | adresseerbaarObjectIdentificatie  | 0000000000000000 |
+    | groep          | veld                             | element | waarde           |
+    | naam           | geslachtsnaam                    | 02.40   | .                |
+    | verblijfplaats | straat                           | 11.10   | .                |
+    | verblijfplaats | huisnummer                       | 11.20   | 0                |
+    | verblijfplaats | woonplaats                       | 11.70   | .                |
+    | verblijfplaats | nummeraanduidingIdentificatie    | 11.90   | 0000000000000000 |
+    | verblijfplaats | adresseerbaarObjectIdentificatie | 11.80   | 0000000000000000 |
 
   Scenario: onbekend waarde in een partner voor soortVerbintenis
     Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -70,7 +70,7 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                | waarde     |
     | burgerservicenummer | 999992934  |
-    En de persoon met burgerservicenummer '999992934' heeft de volgende actueel geldige reisdocumentnummers
+    En de persoon met burgerservicenummer '999992934' heeft de volgende actueel geldige reisdocumentnummers (35.20)
     | reisdocumentnummers |
     | .........           |
     | Pk5Q8cA31           |
@@ -82,7 +82,7 @@ Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
     Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
     | naam                  | waarde    |
     | burgerservicenummer   | 999992934 |
-    En bevat de persoon met burgerservicenummer '999992934' alleen de volgende reisdocumentnummers
+    En bevat de persoon met burgerservicenummer '999992934' alleen de volgende 'reisdocumentnummers'
     | reisdocumentnummers |
     | Pk5Q8cA31           |
 
@@ -113,8 +113,8 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | naam                | waarde     |
     | burgerservicenummer | 999992934  |
     En de persoon heeft de volgende <groep> gegevens
-    | naam        | waarde   |
-    | <veld>.code | <waarde> |
+    | naam               | waarde   |
+    | <veld> (<element>) | <waarde> |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                             |
     | type                | RaadpleegMetBurgerservicenummer    |
@@ -125,22 +125,23 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | burgerservicenummer   | 999992934 |
 
     Voorbeelden:
-    | groep          | veld                    | waarde |
-    | geboorte       | plaats                  | 0000   |
-    | geboorte       | land                    | 0000   |
-    | overlijden     | plaats                  | 0000   |
-    | overlijden     | land                    | 0000   |
-    | verblijfplaats | gemeenteVanInschrijving | 0000   |
-    | verblijfplaats | land                    | 0000   |
-    | verblijfplaats | landVanwaarIngeschreven | 0000   |
-    | verblijfstitel | aanduiding              | 00     |
+    | groep          | veld                    | element | waarde |
+    | geboorte       | plaats                  | 03.20   | 0000   |
+    | geboorte       | land                    | 03.30   | 0000   |
+    | overlijden     | plaats                  | 08.20   | 0000   |
+    | overlijden     | land                    | 08.30   | 0000   |
+    | verblijfplaats | gemeenteVanInschrijving | 09.10   | 0000   |
+    | verblijfplaats | land                    | 13.10   | 0000   |
+    | verblijfplaats | landVanwaarIngeschreven | 14.10   | 0000   |
+    | verblijfstitel | aanduiding              | 39.10   | 00     |
 
   Scenario: buitenlandse plaats zonder code
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                | waarde     |
     | burgerservicenummer | 999992934  |
     En de persoon heeft de volgende geboorte gegevens
-    | plaats.omschrijving | Brussel |
+    | naam           | waarde  |
+    | plaats (03.20) | Brussel |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                              |
     | type                | RaadpleegMetBurgerservicenummer     |
@@ -161,8 +162,8 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | naam                        | waarde             |
     | burgerservicenummer         | 999992935          |
     En de <relatie> met burgerservicenummer '999992935' heeft de volgende <groep> gegevens
-    | naam        | waarde   |
-    | <veld>.code | <waarde> |
+    | naam               | waarde   |
+    | <veld> (<element>) | <waarde> |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                                                                     |
     | type                | RaadpleegMetBurgerservicenummer                                            |
@@ -173,25 +174,25 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | burgerservicenummer   | 999992934 |
 
     Voorbeelden:
-    | relatie  | groep                       | veld   | waarde |
-    | ouders   | geboorte                    | plaats | 0000   |
-    | ouders   | geboorte                    | land   | 0000   |
-    | partners | geboorte                    | plaats | 0000   |
-    | partners | geboorte                    | land   | 0000   |
-    | partners | aangaanHuwelijkPartnerschap | plaats | 0000   |
-    | partners | aangaanHuwelijkPartnerschap | land   | 0000   |
-    | kinderen | geboorte                    | plaats | 0000   |
-    | kinderen | geboorte                    | land   | 0000   |
+    | relatie  | groep                       | veld   | element | waarde |
+    | ouders   | geboorte                    | plaats | 03.20   | 0000   |
+    | ouders   | geboorte                    | land   | 03.30   | 0000   |
+    | partners | geboorte                    | plaats | 03.20   | 0000   |
+    | partners | geboorte                    | land   | 03.30   | 0000   |
+    | partners | aangaanHuwelijkPartnerschap | plaats | 06.20   | 0000   |
+    | partners | aangaanHuwelijkPartnerschap | land   | 06.30   | 0000   |
+    | kinderen | geboorte                    | plaats | 03.20   | 0000   |
+    | kinderen | geboorte                    | land   | 03.30   | 0000   |
 
   Scenario: onbekend waarde voor nationaliteit
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                | waarde     |
     | burgerservicenummer | 999992934  |
     En de persoon met burgerservicenummer '999992934' heeft de volgende nationaliteit gegevens
-    | naam                  | waarde   |
-    | nationaliteit         | 0000     |
-    | redenOpname           | 311      |
-    | datumIngangGeldigheid | 20030417 |
+    | naam                          | waarde   |
+    | nationaliteit (05.10)         | 0000     |
+    | redenOpname (63.10)           | 311      |
+    | datumIngangGeldigheid (85.10) | 20030417 |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                              |
     | type                | RaadpleegMetBurgerservicenummer     |
@@ -201,19 +202,18 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | naam                  | waarde    |
     | burgerservicenummer   | 999992934 |
     En bevat de persoon met burgerservicenummer '999992934' een nationaliteit met alleen de volgende gegevens
-    | redenOpname.code            | 311                                  |
-    | redenOpname.omschrijving    | Vaststelling onbekende nationaliteit |
-    | datumIngangGeldigheid.datum | 2003-04-17                           |
+    | redenOpname           | 311        |
+    | datumIngangGeldigheid | 2003-04-17 |
     
   Scenario: onbekend waarde voor reden opname nationaliteit
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                | waarde     |
     | burgerservicenummer | 999992934  |
     En de persoon met burgerservicenummer '999992934' heeft de volgende nationaliteit gegevens
-    | naam                  | waarde   |
-    | nationaliteit         | 0052     |
-    | redenOpname           | 000      |
-    | datumIngangGeldigheid | 20030417 |
+    | naam                          | waarde   |
+    | nationaliteit (05.10)         | 0052     |
+    | redenOpname (63.10)           | 000      |
+    | datumIngangGeldigheid (85.10) | 20030417 |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                              |
     | type                | RaadpleegMetBurgerservicenummer     |
@@ -223,9 +223,8 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | naam                  | waarde    |
     | burgerservicenummer   | 999992934 |
     En bevat de persoon met burgerservicenummer '999992934' een nationaliteit met alleen de volgende gegevens
-    | nationaliteit.code          | 0052       |
-    | nationaliteit.omschrijving  | Belgische  |
-    | datumIngangGeldigheid.datum | 2003-04-17 |
+    | nationaliteit         | 0052       |
+    | datumIngangGeldigheid | 2003-04-17 |
 
 Rule: de onbekendwaarde voor geslachtsaanduiding wordt wel geleverd
 
@@ -233,7 +232,7 @@ Rule: de onbekendwaarde voor geslachtsaanduiding wordt wel geleverd
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
-    | geslachtsaanduiding         | O         |
+    | geslachtsaanduiding (04.10) | O         |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                                  |
     | type                | RaadpleegMetBurgerservicenummer         |
@@ -249,13 +248,14 @@ Rule: de onbekendwaarde voor geslachtsaanduiding wordt wel geleverd
 
 Rule: de onbekendwaarde voor redenOpschortingBijhouding wordt wel geleverd
 
-  Scenario: een onbekendwaarde bij redenOpschortingBijhouding wordt wel opgenomen in de response
+  Scenario: een onbekendwaarde bij reden opschorting bijhouding wordt wel opgenomen in de response
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     En de persoon heeft de volgende opschortingBijhouding gegevens
-    | reden | .        |
-    | datum | 20211218 |
+    | naam          | waarde   |
+    | datum (67.10) | 20211218 |
+    | reden (67.20) | .        |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                                  |
     | type                | RaadpleegMetBurgerservicenummer         |
@@ -268,85 +268,69 @@ Rule: de onbekendwaarde voor redenOpschortingBijhouding wordt wel geleverd
     | naam               | waarde     |
     | reden.code         | .          |
     | reden.omschrijving | onbekend   |
-    | datum.type         | Datum      |
-    | datum.datum        | 2021-12-18 |
+    | datum              | 2021-12-18 |
 
 Rule: datumvelden waarde "00000000": worden vertaald naar OnbekendDatum
 
-  Scenario: een onbekendwaarde bij redenOpschortingBijhouding wordt wel opgenomen in de response
+  Abstract Scenario: volledig onbekende datum in <groep> <element>
     Gegeven het systeem heeft een persoon met de volgende gegevens
-    | naam                        | waarde    |
-    | burgerservicenummer         | 999992934 |
-    En de persoon heeft de volgende opschortingBijhouding gegevens
-    | reden | O        |
-    | datum | 00000000 |
+    | naam                | waarde    |
+    | burgerservicenummer | 555550001 |
+    En de persoon heeft de volgende <groep> gegevens
+    | naam      | waarde   |
+    | <element> | 00000000 |
     Als personen wordt gezocht met de volgende parameters
-    | naam                | waarde                                  |
-    | type                | RaadpleegMetBurgerservicenummer         |
-    | burgerservicenummer | 999992934                               |
-    | fields              | burgerservicenummer,redenOpschortingBijhouding |
+    | naam                | waarde                             |
+    | type                | RaadpleegMetBurgerservicenummer    |
+    | burgerservicenummer | 555550001                          |
+    | fields              | burgerservicenummer,<groep>.<veld> |
     Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
     | naam                  | waarde    |
     | burgerservicenummer   | 999992934 |
-    En bevat de persoon met burgerservicenummer '999992934' de volgende 'opschortingBijhouding' gegevens
+    En bevat de persoon met burgerservicenummer '555550001' alleen de volgende '<groep>' gegevens
     | naam               | waarde        |
-    | reden.code         | O             |
-    | reden.omschrijving | overlijden    |
     | datum.type         | OnbekendDatum |
     | datum.onbekend     | true          |
 
-  Scenario: er wordt geen link gemaakt op basis van een onbekendwaarde
-    Gegeven de persoon heeft een reisdocument met reisdocumentnummer "........."
-    En de persoon heeft geen ander actueel reisdocument
-    Als de persoon wordt geraadpleegd
-    Dan is in het antwoord _links.reisdocumenten niet aanwezig
+    Voorbeelden:
+    | groep                 | element                                       | veld                                  |
+    | geboorte              | datum (03.10)                                 | datum                                 |
+    | overlijden            | datum (08.10)                                 | datum                                 |
+    | opschortingBijhouding | datum (67.10)                                 | datum                                 |
+    | verblijfplaats        | datumInschrijvingInGemeente (09.20)           | datumInschrijvingInGemeente           |
+    | verblijfplaats        | datumAanvangAdreshouding (10.30)              | datumVan                              |
+    | verblijfplaats        | datumAanvangAdresBuitenland (13.20)           | datumVan                              |
+    | verblijfstitel        | datumEinde (39.20)                            | datumEinde                            |
+    | verblijfstitel        | datumIngang (39.30)                           | datumIngang                           |
+    | kiesrecht             | einddatumUitsluitingEuropeesKiesrecht (31.30) | einddatumUitsluitingEuropeesKiesrecht |
+    | kiesrecht             | einddatumUitsluitingKiesrecht (38.30)         | einddatumUitsluitingKiesrecht         |
 
-  Scenario: vullen van indicatieVestigingVanuitBuitenland
-    Gegeven de registratie persoon 999990317 kent een verblijfplaats.datumVestigingInNederland = 19900808
-    Als de persoon met burgerservicenummer 999990317 wordt geraadpleegd
-    Dan heeft in het antwoord verblijfplaats.datumVestigingInNederland.datum de waarde 1990-08-08
-    En heeft attribuut verblijfplaats.indicatieVestigingVanuitBuitenland de waarde true
+  Abstract Scenario: volledig onbekende datum bij <relatie> in <groep> datum
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 555550001  |
+    En de persoon heeft een <relatie> met de volgende gegevens
+    | naam                        | waarde             |
+    | burgerservicenummer         | 555550002          |
+    En de <relatie> met burgerservicenummer '555550002' heeft de volgende <groep> gegevens
+    | naam              | waarde   |
+    | datum (<element>) | 00000000 |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                                     |
+    | type                | RaadpleegMetBurgerservicenummer                                            |
+    | burgerservicenummer | 555550001                                                                  |
+    | fields              | burgerservicenummer,<relatie>.burgerservicenummer,<relatie>.<groep>.<veld> |
+    Dan bevat de <relatie> met burgerservicenummer '555550002' alleen de volgende '<groep>' gegevens
+    | naam           | waarde        |
+    | datum.type     | OnbekendDatum |
+    | datum.onbekend | true          |
 
-    Gegeven de registratie persoon kent een verblijfplaats.datumVestigingInNederland = 00000000
-    Als de persoon wordt geraadpleegd
-    Dan heeft attribuut verblijfplaats.indicatieVestigingVanuitBuitenland de waarde true
-    En is in het antwoord verblijfplaats.datumVestigingInNederland niet aanwezig
-
-    Gegeven de registratie persoon 999993653 kent geen verblijfplaats.datumVestigingInNederland
-    Als de persoon met burgerservicenummer 999993653 wordt geraadpleegd
-    Dan is in het antwoord verblijfplaats.datumVestigingInNederland niet aanwezig
-    En is in het antwoord verblijfplaats.indicatieVestigingVanuitBuitenland niet aanwezig
-
-  Scenario: vullen van vanuitVertrokkenOnbekendWaarheen
-    Gegeven de registratie persoon 999995121 kent een verblijfplaats.landVanwaarIngeschreven = 0000
-    Als de persoon met burgerservicenummer 999995121 wordt geraadpleegd
-    Dan is in het antwoord verblijfplaats.landVanwaarIngeschreven niet aanwezig
-    En heeft attribuut verblijfplaats.vanuitVertrokkenOnbekendWaarheen de waarde true
-
-    Gegeven de registratie persoon 999990317 kent een verblijfplaats.landVanwaarIngeschreven = 7046
-    Als de persoon met burgerservicenummer 999990317 wordt geraadpleegd
-    Dan heeft attribuut verblijfplaats.landVanwaarIngeschreven.code de waarde 7046
-    En is in het antwoord verblijfplaats.vanuitVertrokkenOnbekendWaarheen niet aanwezig
-
-    Gegeven de registratie persoon 999993653 kent geen verblijfplaats.landVanwaarIngeschreven
-    Als de persoon met burgerservicenummer 999993653 wordt geraadpleegd
-    Dan is in het antwoord verblijfplaats.landVanwaarIngeschreven niet aanwezig
-    En is in het antwoord verblijfplaats.vanuitVertrokkenOnbekendWaarheen niet aanwezig
-
-  Scenario: vullen van vertrokkenOnbekendWaarheen
-    Gegeven de registratie persoon 999993586 kent een verblijfplaats.verblijfBuitenland.land = 0000
-    Als de persoon met burgerservicenummer 999993586 wordt geraadpleegd
-    Dan is in het antwoord verblijfplaats.verblijfBuitenland.land niet aanwezig
-    En heeft attribuut verblijfplaats.verblijfBuitenland.vertrokkenOnbekendWaarheen de waarde true
-
-    Gegeven de registratie persoon 999992326 kent een verblijfplaats.verblijfBuitenland.land = 6003
-    Als de persoon met burgerservicenummer 999992326 wordt geraadpleegd
-    Dan heeft attribuut verblijfplaats.verblijfBuitenland.land.code de waarde 6003
-    En is in het antwoord verblijfplaats.verblijfBuitenland.vertrokkenOnbekendWaarheen niet aanwezig
-
-    Gegeven de registratie persoon 999993653 is in een Nederlandse gemeente
-    Als de persoon met burgerservicenummer 999993653 wordt geraadpleegd
-    Dan is in het antwoord verblijfplaats.verblijfBuitenland niet aanwezig
+    Voorbeelden:
+    | relatie  | groep                       | element |
+    | ouders   | geboorte                    | 03.10   |
+    | partners | aangaanHuwelijkPartnerschap | 06.10   |
+    | partners | geboorte                    | 03.10   |
+    | kinderen | geboorte                    | 03.10   |
 
 Rule: vertalen (onbekend)waarden naar indicator
   - elke waarde voor datumVestigingInNederland (incl. 00000000) geeft indicatieVestigingVanuitBuitenland met de waarde true
@@ -448,3 +432,4 @@ Rule: vertalen (onbekend)waarden naar indicator
     | 00000000 | 1403   | 6030 | true               |
     | 00000000 | 0000   | 0000 | true               |
     | 00000000 |        |      | true               |
+    |          |        |      |                    |

--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -3,87 +3,298 @@
 Functionaliteit: Als gebruiker van de API wil ik geen onbekend waardes ontvangen
   zodat ik deze niet hoef te (kunnen) interpreteren en ik geen code voor hoef te schrijven om deze situatie af te vangen
 
-  Wanneer in de registratie specifieke waarden gereserveerd zijn voor ee onbekende waarde, worden deze waarden niet doorgegeven in de API.
-  Wanneer een element in de registratie een onbekendwaarde heeft, wordt het corresponderende attribbuut niet opgenomen in de response.
-  Wanneer op basis van een elementwaarde een link naar een andere resource wordt opgebouwd, wordt in geval van een onbekendwaarde de link niet opgenomen in de response.
-
-  Uitzondering is geslachtsaanduiding waarde "O" (onbekend), deze wordt doorgegeven in de API.
-
-  Voor onbekend waardes voor datumvelden, zie feature onvolledige_datum.feature.
-
-  Het gaat om de volgende properties en onbekend waardes van de persoon:
-    | property                                         | onbekend waarde  |
-    | ------------------------------------------------ | ---------------- |
-    | naam.geslachtsnaam                               | .                |
-    | geboorte.plaats                                  | 0000             |
-    | geboorte.land                                    | 0000             |
-    | overlijden.plaats                                | 0000             |
-    | overlijden.land                                  | 0000             |
-    | nationaliteit.nationaliteit                      | 0000             |
-    | nationaliteit.redenOpname                        | 000              |
-    | verblijfplaats.gemeenteVanInschrijving           | 0000             |
-    | verblijfplaats.straatnaam                        | .                |
-    | verblijfplaats.huisnummer                        | 0                |
-    | verblijfplaats.woonplaatsnaam                    | .                |
-    | verblijfplaats.identificatiecodeNummeraanduiding | 0000000000000000 |
-    | verblijfplaats.identificatiecodeVerblijfplaats   | 0000000000000000 |
-    | verblijfplaats.verblijfBuitenland.land           | 0000             |
-    | verblijfplaats.landVanwaarIngeschreven           | 0000             |
-    | verblijfstitel.aanduiding                        | 00               |
-
-  Het gaat om de volgende properties en onbekend waardes van de ouder:
-    | property                                         | onbekend waarde  |
-    | ------------------------------------------------ | ---------------- |
-    | naam.geslachtsnaam                               | .                |
-    | geboorte.plaats                                  | 0000             |
-    | geboorte.land                                    | 0000             |
-
-  Het gaat om de volgende properties en onbekend waardes van de partner:
-    | property                                         | onbekend waarde  |
-    | ------------------------------------------------ | ---------------- |
-    | naam.geslachtsnaam                               | .                |
-    | geboorte.plaats                                  | 0000             |
-    | geboorte.land                                    | 0000             |
-    | soortVerbintenis                                 | .                |
-    | aangaanHuwelijk_Partnerschap.plaats              | 0000             |
-    | aangaanHuwelijk_Partnerschap.land                | 0000             |
-
-  Het gaat om de volgende properties en onbekend waardes van het kind:
-    | property                                         | onbekend waarde  |
-    | ------------------------------------------------ | ---------------- |
-    | naam.geslachtsnaam                               | .                |
-    | geboorte.plaats                                  | 0000             |
-    | geboorte.land                                    | 0000             |
+  Wanneer in de registratie specifieke waarden gereserveerd zijn voor een onbekende waarde, worden deze waarden niet doorgegeven in de API.
+  Wanneer een element in de registratie een standaardwaarde heeft, die betekent dat de waarde onbekend is, wordt het corresponderende veld niet opgenomen in de response.
 
 
-  Het gaat om de volgende properties en onbekend waardes van het reisdocument:
-    | property                                         | onbekend waarde  |
-    | ------------------------------------------------ | ---------------- |
-    | reisdocumentnummer                               | .........        |
-    | soortReisdocument                                | ..
-    | autoriteitAfgifte                                | ..               |
-    | aanduidingInhoudingOfVermissing                  | .                |
+Rule: een veld wordt niet opgenomen wanneer het de standaardwaarde bevat
+  Het gaat om de volgende properties en standaardwaardes van de persoon:
+  | property                                         | standaardwaarde  |
+  | ------------------------------------------------ | ---------------- |
+  | naam.geslachtsnaam                               | .                |
+  | verblijfplaats.straat                            | .                |
+  | verblijfplaats.huisnummer                        | 0                |
+  | verblijfplaats.woonplaats                        | .                |
+  | verblijfplaats.nummeraanduidingIdentificatie     | 0000000000000000 |
+  | verblijfplaats.adresseerbaarObjectIdentificatie  | 0000000000000000 |
+  | ouders.naam.geslachtsnaam                        | .                |
+  | partners.naam.geslachtsnaam                      | .                |
+  | partners.soortVerbintenis                        | .                |
+  | kinderen.naam.geslachtsnaam                      | .                |
+  | reisdocumentnummers                              | .........        |
 
-  Een aantal onbekendwaardes worden vertaald naar indicatoren die de betekenis van de onbekendwaarde, dan wel de betekenis van de aanwezigheid van een waarde.
-  - verblijfplaats.indicatieVestigingVanuitBuitenland krijgt de waarde true wanneer verblijfplaats.datumVestigingInNederland een waarde heeft (incl. 00000000)
-  - verblijfplaats.vanuitVertrokkenOnbekendWaarheen krijgt de waarde true wanneer verblijfplaats.landVanwaarIngeschreven = 0000
-  - verblijfplaats.verblijfBuitenland.vertrokkenOnbekendWaarheen krijgt de waarde true wanneer verblijfplaats.verblijfBuitenland.land = 0000.
-  - overlijden.indicatieOverleden: zie feature onvolledige_datum.feature
+  Abstract Scenario: onbekend waarde "<waarde>" voor <veld>
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon heeft de volgende <groep> gegevens
+    | naam   | waarde   |
+    | <veld> | <waarde> |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                             |
+    | type                | RaadpleegMetBurgerservicenummer    |
+    | burgerservicenummer | 999992934                          |
+    | fields              | burgerservicenummer,<groep>.<veld> |
+    Dan bevat de persoon met burgerservicenummer '999992934' alleen de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
 
+    Voorbeelden:
+    | groep          | veld                              | waarde           |
+    | naam           | geslachtsnaam                     | .                |
+    | verblijfplaats | straat                            | .                |
+    | verblijfplaats | huisnummer                        | 0                |
+    | verblijfplaats | woonplaats                        | .                |
+    | verblijfplaats | nummeraanduidingIdentificatie     | 0000000000000000 |
+    | verblijfplaats | adresseerbaarObjectIdentificatie  | 0000000000000000 |
 
-  Scenario: een onbekendwaarde wordt niet opgenomen in de response
-    Gegeven in de registratie heeft de straatnaam van de verblijfplaats de waarde "."
-    Als de persoon wordt geraadpleegd
-    Dan is in het antwoord verblijfplaats.straatnaam niet aanwezig
+  Scenario: onbekend waarde in een partner voor soortVerbintenis
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon heeft een partner met de volgende gegevens
+    | naam                        | waarde             |
+    | burgerservicenummer         | 999992935          |
+    En de <relatie> met burgerservicenummer '999992935' heeft de volgende soortVerbintenis gegevens
+    | naam        | waarde   |
+    | code        | .        |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                                     |
+    | type                | RaadpleegMetBurgerservicenummer                                            |
+    | burgerservicenummer | 999992934                                                                  |
+    | fields              | burgerservicenummer,partners.soortVerbintenis                              |
+    Dan bevat de persoon met burgerservicenummer '999992934' alleen de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
 
-    Gegeven de geboorteplaats van de ouder is niet bekend
-    Als de ouder wordt geraadpleegd
-    Dan is in het antwoord geboorte.plaats niet aanwezig
+  Scenario: onbekend waarde voor reisdocumentnummer
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon met burgerservicenummer '999992934' heeft de volgende actueel geldige reisdocumentnummers
+    | reisdocumentnummers |
+    | .........           |
+    | Pk5Q8cA31           |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                  |
+    | type                | RaadpleegMetBurgerservicenummer         |
+    | burgerservicenummer | 999992934                               |
+    | fields              | burgerservicenummer,reisdocumentnummers |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' alleen de volgende reisdocumentnummers
+    | reisdocumentnummers |
+    | Pk5Q8cA31           |
+
+Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbekendwaarde voor de betreffende tabel bevat
+  Het gaat om de volgende properties en standaardwaardes van de persoon:
+  | property                                    | standaardwaarde |
+  | geboorte.plaats                             | 0000            |
+  | geboorte.land                               | 0000            |
+  | overlijden.plaats                           | 0000            |
+  | overlijden.land                             | 0000            |
+  | nationaliteit.nationaliteit                 | 0000            |
+  | nationaliteit.redenOpname                   | 000             |
+  | verblijfplaats.gemeenteVanInschrijving      | 0000            |
+  | verblijfplaats.land                         | 0000            |
+  | verblijfplaats.landVanwaarIngeschreven      | 0000            |
+  | verblijfstitel.aanduiding                   | 00              |
+  | ouders.geboorte.plaats                      | 0000            |
+  | ouders.geboorte.land                        | 0000            |
+  | partners.geboorte.plaats                    | 0000            |
+  | partners.geboorte.land                      | 0000            |
+  | partners.aangaanHuwelijkPartnerschap.plaats | 0000            |
+  | partners.aangaanHuwelijkPartnerschap.land   | 0000            |
+  | kinderen.geboorte.plaats                    | 0000            |
+  | kinderen.geboorte.land                      | 0000            |
+  
+  Abstract Scenario: onbekend waarde voor <groep> <veld>
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon heeft de volgende <groep> gegevens
+    | naam        | waarde   |
+    | <veld>.code | <waarde> |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                             |
+    | type                | RaadpleegMetBurgerservicenummer    |
+    | burgerservicenummer | 999992934                          |
+    | fields              | burgerservicenummer,<groep>.<veld> |
+    Dan bevat de persoon met burgerservicenummer '999992934' alleen de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+
+    Voorbeelden:
+    | groep          | veld                    | waarde |
+    | geboorte       | plaats                  | 0000   |
+    | geboorte       | land                    | 0000   |
+    | overlijden     | plaats                  | 0000   |
+    | overlijden     | land                    | 0000   |
+    | verblijfplaats | gemeenteVanInschrijving | 0000   |
+    | verblijfplaats | land                    | 0000   |
+    | verblijfplaats | landVanwaarIngeschreven | 0000   |
+    | verblijfstitel | aanduiding              | 00     |
+
+  Scenario: buitenlandse plaats zonder code
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon heeft de volgende geboorte gegevens
+    | plaats.omschrijving | Brussel |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                              |
+    | type                | RaadpleegMetBurgerservicenummer     |
+    | burgerservicenummer | 999992934                           |
+    | fields              | burgerservicenummer,geboorte.plaats |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' alleen de volgende 'geboorte' gegevens
+    | naam                | waarde  |
+    | plaats.omschrijving | Brussel |
+
+  Abstract Scenario: onbekend waarde in een <relatie> voor <groep> <veld>
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon heeft een <relatie> met de volgende gegevens
+    | naam                        | waarde             |
+    | burgerservicenummer         | 999992935          |
+    En de <relatie> met burgerservicenummer '999992935' heeft de volgende <groep> gegevens
+    | naam        | waarde   |
+    | <veld>.code | <waarde> |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                                     |
+    | type                | RaadpleegMetBurgerservicenummer                                            |
+    | burgerservicenummer | 999992934                                                                  |
+    | fields              | burgerservicenummer,<relatie>.burgerservicenummer,<relatie>.<groep>.<veld> |
+    Dan bevat de persoon met burgerservicenummer '999992934' alleen de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+
+    Voorbeelden:
+    | relatie  | groep                       | veld   | waarde |
+    | ouders   | geboorte                    | plaats | 0000   |
+    | ouders   | geboorte                    | land   | 0000   |
+    | partners | geboorte                    | plaats | 0000   |
+    | partners | geboorte                    | land   | 0000   |
+    | partners | aangaanHuwelijkPartnerschap | plaats | 0000   |
+    | partners | aangaanHuwelijkPartnerschap | land   | 0000   |
+    | kinderen | geboorte                    | plaats | 0000   |
+    | kinderen | geboorte                    | land   | 0000   |
+
+  Scenario: onbekend waarde voor nationaliteit
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon met burgerservicenummer '999992934' heeft de volgende nationaliteit gegevens
+    | naam                  | waarde   |
+    | nationaliteit         | 0000     |
+    | redenOpname           | 311      |
+    | datumIngangGeldigheid | 20030417 |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                              |
+    | type                | RaadpleegMetBurgerservicenummer     |
+    | burgerservicenummer | 999992934                           |
+    | fields              | burgerservicenummer,nationaliteiten |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' een nationaliteit met alleen de volgende gegevens
+    | redenOpname.code            | 311                                  |
+    | redenOpname.omschrijving    | Vaststelling onbekende nationaliteit |
+    | datumIngangGeldigheid.datum | 2003-04-17                           |
+    
+  Scenario: onbekend waarde voor reden opname nationaliteit
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde     |
+    | burgerservicenummer | 999992934  |
+    En de persoon met burgerservicenummer '999992934' heeft de volgende nationaliteit gegevens
+    | naam                  | waarde   |
+    | nationaliteit         | 0052     |
+    | redenOpname           | 000      |
+    | datumIngangGeldigheid | 20030417 |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                              |
+    | type                | RaadpleegMetBurgerservicenummer     |
+    | burgerservicenummer | 999992934                           |
+    | fields              | burgerservicenummer,nationaliteiten |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' een nationaliteit met alleen de volgende gegevens
+    | nationaliteit.code          | 0052       |
+    | nationaliteit.omschrijving  | Belgische  |
+    | datumIngangGeldigheid.datum | 2003-04-17 |
+
+Rule: de onbekendwaarde voor geslachtsaanduiding wordt wel geleverd
 
   Scenario: een onbekendwaarde bij geslachtsaanduiding wordt wel opgenomen in de response
-    Gegeven in de registratie heeft de geslachtsaanduiding de waarde "O" (onbekend)
-    Als de persoon wordt geraadpleegd
-    Dan heeft attribuut geslachtsaanduiding de waarde "Onbekend"
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                        | waarde    |
+    | burgerservicenummer         | 999992934 |
+    | geslachtsaanduiding         | O         |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                  |
+    | type                | RaadpleegMetBurgerservicenummer         |
+    | burgerservicenummer | 999992934                               |
+    | fields              | burgerservicenummer,geslachtsaanduiding |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' de volgende 'geslachtsaanduiding' gegevens
+    | naam         | waarde   |
+    | code         | O        |
+    | omschrijving | onbekend |
+
+Rule: de onbekendwaarde voor redenOpschortingBijhouding wordt wel geleverd
+
+  Scenario: een onbekendwaarde bij redenOpschortingBijhouding wordt wel opgenomen in de response
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                        | waarde    |
+    | burgerservicenummer         | 999992934 |
+    En de persoon heeft de volgende opschortingBijhouding gegevens
+    | reden | .        |
+    | datum | 20211218 |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                  |
+    | type                | RaadpleegMetBurgerservicenummer         |
+    | burgerservicenummer | 999992934                               |
+    | fields              | burgerservicenummer,redenOpschortingBijhouding |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' de volgende 'opschortingBijhouding' gegevens
+    | naam               | waarde     |
+    | reden.code         | .          |
+    | reden.omschrijving | onbekend   |
+    | datum.type         | Datum      |
+    | datum.datum        | 2021-12-18 |
+
+Rule: datumvelden waarde "00000000": worden vertaald naar OnbekendDatum
+
+  Scenario: een onbekendwaarde bij redenOpschortingBijhouding wordt wel opgenomen in de response
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                        | waarde    |
+    | burgerservicenummer         | 999992934 |
+    En de persoon heeft de volgende opschortingBijhouding gegevens
+    | reden | O        |
+    | datum | 00000000 |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                  |
+    | type                | RaadpleegMetBurgerservicenummer         |
+    | burgerservicenummer | 999992934                               |
+    | fields              | burgerservicenummer,redenOpschortingBijhouding |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                  | waarde    |
+    | burgerservicenummer   | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' de volgende 'opschortingBijhouding' gegevens
+    | naam               | waarde        |
+    | reden.code         | O             |
+    | reden.omschrijving | overlijden    |
+    | datum.type         | OnbekendDatum |
+    | datum.onbekend     | true          |
 
   Scenario: er wordt geen link gemaakt op basis van een onbekendwaarde
     Gegeven de persoon heeft een reisdocument met reisdocumentnummer "........."
@@ -137,3 +348,104 @@ Functionaliteit: Als gebruiker van de API wil ik geen onbekend waardes ontvangen
     Gegeven de registratie persoon 999993653 is in een Nederlandse gemeente
     Als de persoon met burgerservicenummer 999993653 wordt geraadpleegd
     Dan is in het antwoord verblijfplaats.verblijfBuitenland niet aanwezig
+
+Rule: vertalen (onbekend)waarden naar indicator
+  - elke waarde voor datumVestigingInNederland (incl. 00000000) geeft indicatieVestigingVanuitBuitenland met de waarde true
+  - onbekend land vanwaar ingeschreven (waarde 0000) geeft vanuitVerblijfplaatsOnbekend met de waarde true
+  - onbekend land verblijf buitenland (waarde 0000) geeft verblijfplaatsOnbekend
+  - elke waarde voor overlijdensdatum (incl. 00000000) geeft indicatieOverleden met de waarde true
+
+  Abstract Scenario: indicatieVestigingVanuitBuitenland en vanuitVerblijfplaatsOnbekend bij datum vestiging '<datum>' uit land '<land>'
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    En de persoon heeft de volgende verblijfplaats gegevens
+    | naam                      | waarde  |
+    | datumVestigingInNederland | <datum> |
+    | landVanwaarIngeschreven   | <land>  |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                                                                            |
+    | type                | RaadpleegMetBurgerservicenummer                                                                                   |
+    | burgerservicenummer | 999992934                                                                                                         |
+    | fields              | burgerservicenummer,verblijfplaats.indicatieVestigingVanuitBuitenland,verblijfplaats.vanuitVerblijfplaatsOnbekend |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' de volgende 'verblijfplaats' gegevens
+    | naam                               | waarde                               |
+    | indicatieVestigingVanuitBuitenland | <indicatieVestigingVanuitBuitenland> |
+    | vanuitVerblijfplaatsOnbekend       | <vanuitVerblijfplaatsOnbekend>       |
+
+    Voorbeelden:
+    | datum    | land | indicatieVestigingVanuitBuitenland | vanuitVerblijfplaatsOnbekend |
+    | 19871402 | 6023 | true                               |                              |
+    | 19490000 | 6024 | true                               |                              |
+    | 19931100 | 6065 | true                               |                              |
+    | 00000000 | 6029 | true                               |                              |
+    | 19871402 | 0000 | true                               | true                         |
+    | 00000000 | 0000 | true                               | true                         |
+    |          |      |                                    |                              |
+
+  Abstract Scenario: verblijfplaatsOnbekend bij land verblijfplaats '<land>'
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    En de persoon heeft de volgende verblijfplaats gegevens
+    | naam                | waarde       |
+    | land                | <land>       |
+    | adresregel1         |              |
+    | adresregel2         | <adresregel2> |
+    | straat              | <straat>     |
+    | huisnummer          | <huisnummer> |
+    | postcode            |              |
+    | locatiebeschrijving |              |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                    |
+    | type                | RaadpleegMetBurgerservicenummer                           |
+    | burgerservicenummer | 999992934                                                 |
+    | fields              | burgerservicenummer,verblijfplaats.type,verblijfplaats.verblijfplaatsOnbekend |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' de volgende 'verblijfplaats' gegevens
+    | naam                   | waarde     |
+    | type                   | <type>     |
+    | verblijfplaatsOnbekend | <onbekend> |
+
+    Voorbeelden:
+    | land | adresregel2 | straat | huisnummer | type                     | onbekend |
+    | 6033 |             |        |            | VerblijfplaatsBuitenland |          |
+    | 6033 | onbekend    |        |            | VerblijfplaatsBuitenland |          |
+    | 0000 |             |        |            | VerblijfplaatsOnbekend   | true     |
+    | 0000 | VOW         |        |            | VerblijfplaatsOnbekend   | true     |
+    |      |             | .      | 0          | Adres                    |          |
+
+  Abstract Scenario: indicatieOverleden bij overlijdensdatum '<overlijdensdatum>'
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    En de persoon heeft de volgende overlijden gegevens
+    | naam   | waarde   |
+    | datum  | <datum>  |
+    | plaats | <plaats> |
+    | land   | <land>   |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                            |
+    | type                | RaadpleegMetBurgerservicenummer                   |
+    | burgerservicenummer | 999992934                                         |
+    | fields              | burgerservicenummer,overlijden.indicatieOverleden |
+    Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    En bevat de persoon met burgerservicenummer '999992934' de volgende 'overlijden' gegevens
+    | naam               | waarde               |
+    | indicatieOverleden | <indicatieOverleden> |
+
+    Voorbeelden:
+    | datum    | plaats | land | indicatieOverleden |
+    | 20010219 | 1403   | 6030 | true               |
+    | 20010200 | 1403   | 6030 | true               |
+    | 20010000 | 1403   | 6030 | true               |
+    | 00000000 | 1403   | 6030 | true               |
+    | 00000000 | 0000   | 0000 | true               |
+    | 00000000 |        |      | true               |

--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -239,12 +239,9 @@ Rule: de onbekendwaarde voor geslachtsaanduiding wordt wel geleverd
     | burgerservicenummer | 999992934                               |
     | fields              | burgerservicenummer,geslachtsaanduiding |
     Dan bevat de persoon met burgerservicenummer '999992934' de volgende gegevens
-    | naam                  | waarde    |
-    | burgerservicenummer   | 999992934 |
-    En bevat de persoon met burgerservicenummer '999992934' de volgende 'geslachtsaanduiding' gegevens
-    | naam         | waarde   |
-    | code         | O        |
-    | omschrijving | onbekend |
+    | naam                | waarde    |
+    | burgerservicenummer | 999992934 |
+    | geslachtsaanduiding | O         |
 
 Rule: de onbekendwaarde voor redenOpschortingBijhouding wordt wel geleverd
 
@@ -265,10 +262,9 @@ Rule: de onbekendwaarde voor redenOpschortingBijhouding wordt wel geleverd
     | naam                  | waarde    |
     | burgerservicenummer   | 999992934 |
     En bevat de persoon met burgerservicenummer '999992934' de volgende 'opschortingBijhouding' gegevens
-    | naam               | waarde     |
-    | reden.code         | .          |
-    | reden.omschrijving | onbekend   |
-    | datum              | 2021-12-18 |
+    | naam  | waarde     |
+    | reden | .          |
+    | datum | 2021-12-18 |
 
 Rule: datumvelden waarde "00000000": worden vertaald naar OnbekendDatum
 

--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -1,5 +1,6 @@
 # language: nl
 
+@proxy
 Functionaliteit: Als gebruiker van de API wil ik geen onbekend waardes ontvangen
   zodat ik deze niet hoef te (kunnen) interpreteren en ik geen code voor hoef te schrijven om deze situatie af te vangen
 


### PR DESCRIPTION
- op basis van nieuwe specificaties v2.0.0
- bepalen onbekend datum
- in structuur andere v2.0.0 features, zodat deze eenvoudiger automatiseerbaar is

bepalen van OnbekendPartner, OnbekendOuder en OnbekendKind wordt opgenomen in resp. partners.feature, ouders.feature en konden.feature

de functionaliteit die beschreven wordt in deze feature moet in zijn geheel worden gerealiseerd in de proxy