### PR TITLE
Geslachtsnaam required in GbaKind

### DIFF
--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -1290,7 +1290,7 @@
             "$ref" : "#/components/schemas/GbaInOnderzoek"
           },
           "naam" : {
-            "$ref" : "#/components/schemas/GbaNaamBasis"
+            "$ref" : "#/components/schemas/GbaKindNaamBasis"
           },
           "geboorte" : {
             "$ref" : "#/components/schemas/GbaGeboorte"
@@ -1376,6 +1376,24 @@
         "properties" : {
           "datum" : {
             "$ref" : "#/components/schemas/GbaDatum"
+          }
+        }
+      },
+      "GbaKindNaamBasis" : {
+        "required" : [ "geslachtsnaam" ],
+        "type" : "object",
+        "properties" : {
+          "voornamen" : {
+            "$ref" : "#/components/schemas/Voornamen"
+          },
+          "adellijkeTitelPredicaat" : {
+            "$ref" : "#/components/schemas/AdellijkeTitelPredicaatType"
+          },
+          "voorvoegsel" : {
+            "$ref" : "#/components/schemas/Voorvoegsel"
+          },
+          "geslachtsnaam" : {
+            "$ref" : "#/components/schemas/Geslachtsnaam"
           }
         }
       }

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -1006,7 +1006,7 @@ components:
         inOnderzoek:
           $ref: '#/components/schemas/GbaInOnderzoek'
         naam:
-          $ref: '#/components/schemas/GbaNaamBasis'
+          $ref: '#/components/schemas/GbaKindNaamBasis'
         geboorte:
           $ref: '#/components/schemas/GbaGeboorte'
     GbaOuder:
@@ -1069,6 +1069,19 @@ components:
       properties:
         datum:
           $ref: '#/components/schemas/GbaDatum'
+    GbaKindNaamBasis:
+      required:
+      - geslachtsnaam
+      type: object
+      properties:
+        voornamen:
+          $ref: '#/components/schemas/Voornamen'
+        adellijkeTitelPredicaat:
+          $ref: '#/components/schemas/AdellijkeTitelPredicaatType'
+        voorvoegsel:
+          $ref: '#/components/schemas/Voorvoegsel'
+        geslachtsnaam:
+          $ref: '#/components/schemas/Geslachtsnaam'
   headers:
     api_version:
       schema:

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -2054,9 +2054,6 @@
             "burgerservicenummer" : {
               "$ref" : "#/components/schemas/Burgerservicenummer"
             },
-            "leeftijd" : {
-              "$ref" : "#/components/schemas/Leeftijd"
-            },
             "inOnderzoek" : {
               "$ref" : "#/components/schemas/KindInOnderzoek"
             },
@@ -2077,9 +2074,6 @@
           "type" : "object",
           "properties" : {
             "burgerservicenummer" : {
-              "type" : "boolean"
-            },
-            "leeftijd" : {
               "type" : "boolean"
             }
           }

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -1556,8 +1556,6 @@ components:
         properties:
           burgerservicenummer:
             $ref: '#/components/schemas/Burgerservicenummer'
-          leeftijd:
-            $ref: '#/components/schemas/Leeftijd'
           inOnderzoek:
             $ref: '#/components/schemas/KindInOnderzoek'
           naam:
@@ -1572,8 +1570,6 @@ components:
       - type: object
         properties:
           burgerservicenummer:
-            type: boolean
-          leeftijd:
             type: boolean
     OnbekendKind:
       allOf:

--- a/specificatie/kind.yaml
+++ b/specificatie/kind.yaml
@@ -14,7 +14,7 @@ components:
         inOnderzoek:
           $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
         naam:
-          $ref: 'naam.yaml#/components/schemas/GbaNaamBasis'
+          $ref: 'naam.yaml#/components/schemas/GbaKindNaamBasis'
         geboorte:
           $ref: 'geboorte.yaml#/components/schemas/GbaGeboorte'
     AbstractKind:

--- a/specificatie/kind.yaml
+++ b/specificatie/kind.yaml
@@ -38,8 +38,6 @@ components:
           properties:
             burgerservicenummer:
               $ref: 'persoon.yaml#/components/schemas/Burgerservicenummer'
-            leeftijd:
-              $ref: 'persoon.yaml#/components/schemas/Leeftijd'
             inOnderzoek:
               $ref: '#/components/schemas/KindInOnderzoek'
             naam:
@@ -62,6 +60,4 @@ components:
         - type: object
           properties:
             burgerservicenummer:
-              type: boolean
-            leeftijd:
               type: boolean

--- a/specificatie/kind.yaml
+++ b/specificatie/kind.yaml
@@ -14,7 +14,7 @@ components:
         inOnderzoek:
           $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
         naam:
-          $ref: 'naam.yaml#/components/schemas/GbaKindNaamBasis'
+          $ref: 'naam.yaml#/components/schemas/GbaNaamBasis'
         geboorte:
           $ref: 'geboorte.yaml#/components/schemas/GbaGeboorte'
     AbstractKind:

--- a/specificatie/naam.yaml
+++ b/specificatie/naam.yaml
@@ -78,21 +78,10 @@ components:
               code: "JV"
               omschrijving: "jonkvrouw"
               soort: "predicaat"
-    GbaKindNaamBasis:
+    GbaNaamBasis:
       type: object
       required:
         - geslachtsnaam
-      properties:
-        voornamen:
-          $ref: '#/components/schemas/Voornamen'
-        adellijkeTitelPredicaat:
-          $ref: '#/components/schemas/AdellijkeTitelPredicaatType'
-        voorvoegsel:
-          $ref: '#/components/schemas/Voorvoegsel'
-        geslachtsnaam:
-          $ref: '#/components/schemas/Geslachtsnaam'
-    GbaNaamBasis:
-      type: object
       properties:
         voornamen:
           $ref: '#/components/schemas/Voornamen'

--- a/specificatie/naam.yaml
+++ b/specificatie/naam.yaml
@@ -80,8 +80,6 @@ components:
               soort: "predicaat"
     GbaNaamBasis:
       type: object
-      required:
-        - geslachtsnaam
       properties:
         voornamen:
           $ref: '#/components/schemas/Voornamen'

--- a/specificatie/naam.yaml
+++ b/specificatie/naam.yaml
@@ -78,6 +78,19 @@ components:
               code: "JV"
               omschrijving: "jonkvrouw"
               soort: "predicaat"
+    GbaKindNaamBasis:
+      type: object
+      required:
+        - geslachtsnaam
+      properties:
+        voornamen:
+          $ref: '#/components/schemas/Voornamen'
+        adellijkeTitelPredicaat:
+          $ref: '#/components/schemas/AdellijkeTitelPredicaatType'
+        voorvoegsel:
+          $ref: '#/components/schemas/Voorvoegsel'
+        geslachtsnaam:
+          $ref: '#/components/schemas/Geslachtsnaam'
     GbaNaamBasis:
       type: object
       properties:


### PR DESCRIPTION
N.a.v. het besluit om de geslachtsnaam van het kind altijd op te vragen als kinderen wordt opgenomen in de fields parameter is de geslachtsnaam in die context verplicht gemaakt. Aangezien 'GbaNaamBasis' ook in andere contexten (o.a. 'GbaPersoon') wordt gebruikt is een 'GbaKindNaambasis' aangemaakt waaraan in 'GbaKind' wordt gerefereerd.