### PR TITLE
fix(oas): zoek met aanduiding met huisnummer

### DIFF
--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -503,6 +503,9 @@
             "inclusiefOverledenPersonen" : {
               "$ref" : "#/components/schemas/InclusiefOverledenPersonen"
             },
+            "aanduidingBijHuisnummer" : {
+              "$ref" : "#/components/schemas/AanduidingBijHuisnummer"
+            },
             "huisletter" : {
               "$ref" : "#/components/schemas/Huisletter"
             },
@@ -527,6 +530,9 @@
           "properties" : {
             "inclusiefOverledenPersonen" : {
               "$ref" : "#/components/schemas/InclusiefOverledenPersonen"
+            },
+            "aanduidingBijHuisnummer" : {
+              "$ref" : "#/components/schemas/AanduidingBijHuisnummer"
             },
             "huisletter" : {
               "$ref" : "#/components/schemas/Huisletter"
@@ -815,6 +821,11 @@
         "type" : "string",
         "description" : "De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/case_insensitive.feature).**\n",
         "example" : "Dirk"
+      },
+      "AanduidingBijHuisnummer" : {
+        "pattern" : "^[a-zA-Z]{2}$",
+        "type" : "string",
+        "example" : "to"
       },
       "Huisletter" : {
         "pattern" : "^[a-zA-Z]{1}$",

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -406,6 +406,8 @@ components:
         properties:
           inclusiefOverledenPersonen:
             $ref: '#/components/schemas/InclusiefOverledenPersonen'
+          aanduidingBijHuisnummer:
+            $ref: '#/components/schemas/AanduidingBijHuisnummer'
           huisletter:
             $ref: '#/components/schemas/Huisletter'
           huisnummer:
@@ -425,6 +427,8 @@ components:
         properties:
           inclusiefOverledenPersonen:
             $ref: '#/components/schemas/InclusiefOverledenPersonen'
+          aanduidingBijHuisnummer:
+            $ref: '#/components/schemas/AanduidingBijHuisnummer'
           huisletter:
             $ref: '#/components/schemas/Huisletter'
           huisnummer:
@@ -646,6 +650,10 @@ components:
       description: |
         De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/case_insensitive.feature).**
       example: Dirk
+    AanduidingBijHuisnummer:
+      pattern: ^[a-zA-Z]{2}$
+      type: string
+      example: to
     Huisletter:
       pattern: ^[a-zA-Z]{1}$
       type: string

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -503,6 +503,9 @@
             "inclusiefOverledenPersonen" : {
               "$ref" : "#/components/schemas/InclusiefOverledenPersonen"
             },
+            "aanduidingBijHuisnummer" : {
+              "$ref" : "#/components/schemas/AanduidingBijHuisnummer"
+            },
             "huisletter" : {
               "$ref" : "#/components/schemas/Huisletter"
             },
@@ -527,6 +530,9 @@
           "properties" : {
             "inclusiefOverledenPersonen" : {
               "$ref" : "#/components/schemas/InclusiefOverledenPersonen"
+            },
+            "aanduidingBijHuisnummer" : {
+              "$ref" : "#/components/schemas/AanduidingBijHuisnummer"
             },
             "huisletter" : {
               "$ref" : "#/components/schemas/Huisletter"
@@ -855,6 +861,11 @@
         "type" : "string",
         "description" : "De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/case_insensitive.feature).**\n",
         "example" : "Dirk"
+      },
+      "AanduidingBijHuisnummer" : {
+        "pattern" : "^[a-zA-Z]{2}$",
+        "type" : "string",
+        "example" : "to"
       },
       "Huisletter" : {
         "pattern" : "^[a-zA-Z]{1}$",

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -406,6 +406,8 @@ components:
         properties:
           inclusiefOverledenPersonen:
             $ref: '#/components/schemas/InclusiefOverledenPersonen'
+          aanduidingBijHuisnummer:
+            $ref: '#/components/schemas/AanduidingBijHuisnummer'
           huisletter:
             $ref: '#/components/schemas/Huisletter'
           huisnummer:
@@ -425,6 +427,8 @@ components:
         properties:
           inclusiefOverledenPersonen:
             $ref: '#/components/schemas/InclusiefOverledenPersonen'
+          aanduidingBijHuisnummer:
+            $ref: '#/components/schemas/AanduidingBijHuisnummer'
           huisletter:
             $ref: '#/components/schemas/Huisletter'
           huisnummer:
@@ -677,6 +681,10 @@ components:
       description: |
         De verzameling namen die, gescheiden door spaties, aan de geslachtsnaam voorafgaat. ** Bij deze query-parameter is het gebruik van een [wildcard](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.3.0/features/wildcard.feature) toegestaan in combinatie met minimaal 2 karakters.** **Zoeken met tekstvelden is [case-Insensitive](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/case_insensitive.feature).**
       example: Dirk
+    AanduidingBijHuisnummer:
+      pattern: ^[a-zA-Z]{2}$
+      type: string
+      example: to
     Huisletter:
       pattern: ^[a-zA-Z]{1}$
       type: string

--- a/specificatie/verblijfplaats.yaml
+++ b/specificatie/verblijfplaats.yaml
@@ -6,6 +6,10 @@ info:
 paths: {}
 components:
   schemas:
+    AanduidingBijHuisnummer:
+      type: string
+      pattern: ^[a-zA-Z]{2}$
+      example: "to"
     Adresregel1:
       type: string
       maxLength: 40

--- a/specificatie/zoek-personen.yaml
+++ b/specificatie/zoek-personen.yaml
@@ -186,6 +186,8 @@ components:
           properties:
             inclusiefOverledenPersonen:
               $ref: '#/components/schemas/InclusiefOverledenPersonen'
+            aanduidingBijHuisnummer:
+              $ref: 'verblijfplaats.yaml#/components/schemas/AanduidingBijHuisnummer'
             huisletter:
               $ref: 'verblijfplaats.yaml#/components/schemas/Huisletter'
             huisnummer:
@@ -205,6 +207,8 @@ components:
           properties:
             inclusiefOverledenPersonen:
               $ref: '#/components/schemas/InclusiefOverledenPersonen'
+            aanduidingBijHuisnummer:
+              $ref: 'verblijfplaats.yaml#/components/schemas/AanduidingBijHuisnummer'
             huisletter:
               $ref: 'verblijfplaats.yaml#/components/schemas/Huisletter'
             huisnummer:


### PR DESCRIPTION
Het is nu niet mogelijk om bij zoeken met postcode en huisnummer of zoeken met straat, huisnummer en gemeente van inschrijving om aanduiding bij huisnummer op te geven als zoek parameter