### PR TITLE
Fix/nationaliteit

### DIFF
--- a/features/in_onderzoek.feature
+++ b/features/in_onderzoek.feature
@@ -1,6 +1,6 @@
 # language: nl
 
-@proxy
+@proxy @post-assert
 Functionaliteit: in onderzoek
   Wanneer de juistheid van een gegeven onderzocht wordt, en daardoor de waarde van een geleverd gegeven mogelijk onjuist is, wordt naast het betreffende veld ook in inOnderzoek een veld met dezelfde naam opgenomen. Deze krijgt dan de boolean waarde true.
 
@@ -739,38 +739,38 @@ Functionaliteit: in onderzoek
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550001 |
-      En de persoon heeft een nationaliteit met de volgende gegevens
-      | naam                                        | waarde                                |
-      | nationaliteit (05.10)                       | <nationaliteit>                       |
-      | aanduidingBijzonderNederlanderschap (65.10) | <aanduidingBijzonderNederlanderschap> |
-      | datumIngangGeldigheid (85.10)               | <datumIngangGeldigheid>               |
-      En de nationaliteit heeft volgende 'inOnderzoek' gegevens
-      | naam                          | waarde   |
-      | aanduidingGegevensInOnderzoek | <waarde> |
-      | datumIngangOnderzoek          | 20220307 |
+      En de persoon heeft een 'nationaliteit' met de volgende gegevens
+      | naam                                     | waarde                                |
+      | nationaliteit (05.10)                    | <nationaliteit>                       |
+      | bijzonder Nederlanderschap (65.10)       | <aanduidingBijzonderNederlanderschap> |
+      | ingangsdatum geldigheid (85.10)          | <datumIngangGeldigheid>               |
+      | aanduiding gegevens in onderzoek (83.10) | <waarde>                              |
+      | datum ingang onderzoek (83.20)           | 20220307                              |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 555550001                       |
-      | fields              | nationaliteiten                 |
-      Dan heeft de nationalieteit de volgende 'inOnderzoek' gegevens
-      | naam                 | waarde          |
-      | type                 | <type>          |
-      | nationaliteit        | <nationaliteit> |
-      | redenOpname          | <redenOpname>   |
-      | datumIngangOnderzoek | 2022-03-07      |
+      | fields              | nationaliteiten.inOnderzoek     |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
+      | naam                                   | waarde                       |
+      | type                                   | <nationaliteit type>         |
+      | inOnderzoek.type                       | <type in onderzoek>          |
+      | inOnderzoek.nationaliteit              | <nationaliteit in onderzoek> |
+      | inOnderzoek.redenOpname                | <redenOpname in onderzoek>   |
+      | inOnderzoek.datumIngangOnderzoek.type  | Datum                        |
+      | inOnderzoek.datumIngangOnderzoek.datum | 2022-03-07                   |
 
       Voorbeelden:
-      | gegeven in onderzoek                                    | nationaliteit | aanduidingBijzonderNederlanderschap | datumIngangGeldigheid | waarde | type | nationaliteit | redenOpname |
-      | hele categorie nationaliteit                            | 0052          |                                     | 19560317              | 040000 | true | true          | true        |
-      | hele categorie bij onbekende nationaliteit              | 0000          |                                     | 00000000              | 040000 | true | true          | true        |
-      | hele categorie bij vastgesteld niet-Nederlander         |               | V                                   | 19710417              | 040000 | true | true          | true        |
-      | hele categorie bij behandeld als Nederlander            |               | B                                   | 19520831              | 040000 | true | true          | true        |
-      | nationaliteit                                           | 0052          |                                     | 19560317              | 040510 | true | true          |             |
-      | onbekende nationaliteit                                 | 0000          |                                     | 19560317              | 040510 | true | true          |             |
-      | reden opname                                            | 0052          |                                     | 19560317              | 046310 |      |               | true        |
-      | bijzonder Nederlanderschap vastgesteld niet-Nederlander |               | V                                   | 19710417              | 046510 | true |               |             |
-      | bijzonder Nederlanderschap behandeld als Nederlander    |               | B                                   | 19710417              | 046510 | true |               |             |
+      | gegeven in onderzoek                                    | nationaliteit | aanduidingBijzonderNederlanderschap | nationaliteit type         | datumIngangGeldigheid | waarde | type in onderzoek | nationaliteit in onderzoek | redenOpname in onderzoek |
+      | hele categorie nationaliteit                            | 0052          |                                     | Nationaliteit              | 19560317              | 040000 | true              | true                       | true                     |
+      | hele categorie bij onbekende nationaliteit              | 0000          |                                     | NationaliteitOnbekend      | 00000000              | 040000 | true              |                            | true                     |
+      | hele categorie bij vastgesteld niet-Nederlander         |               | V                                   | VastgesteldNietNederlander | 19710417              | 040000 | true              |                            | true                     |
+      | hele categorie bij behandeld als Nederlander            |               | B                                   | BehandeldAlsNederlander    | 19520831              | 040000 | true              |                            | true                     |
+      | nationaliteit                                           | 0052          |                                     | Nationaliteit              | 19560317              | 040510 | true              | true                       |                          |
+      | onbekende nationaliteit                                 | 0000          |                                     | NationaliteitOnbekend      | 19560317              | 040510 | true              |                            |                          |
+      | reden opname                                            | 0052          |                                     | Nationaliteit              | 19560317              | 046310 |                   |                            | true                     |
+      | bijzonder Nederlanderschap vastgesteld niet-Nederlander |               | V                                   | VastgesteldNietNederlander | 19710417              | 046510 | true              |                            |                          |
+      | bijzonder Nederlanderschap behandeld als Nederlander    |               | B                                   | BehandeldAlsNederlander    | 19710417              | 046510 | true              |                            |                          |
 
   @proxy
   Rule: onderzoek van een partnergegeven leidt alleen tot inOnderzoek van een samengesteld naamgegeven wanneer daarin de partnernaam wordt gebruikt

--- a/features/nationaliteit.feature
+++ b/features/nationaliteit.feature
@@ -183,12 +183,11 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       En de persoon heeft een 'nationaliteit' met de volgende gegevens
       | naam               | waarde |
       | nationaliteit.code | 0001   |
-      Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                              |
-      | type                | RaadpleegMetBurgerservicenummer     |
-      | burgerservicenummer | 000009830                           |
-      | fields              | burgerservicenummer,nationaliteiten |
-      Dan heeft de persoon met burgerservicenummer '000009830' een 'nationaliteit' met de volgende gegevens
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000009830                       |
+      | fields              | nationaliteiten                 |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
       | naam               | waarde        |
       | type               | Nationaliteit |
       | nationaliteit.code | 0001          |
@@ -202,11 +201,11 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       | naam               | waarde |
       | nationaliteit.code | 0263   |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                              |
-      | type                | RaadpleegMetBurgerservicenummer     |
-      | burgerservicenummer | 555550002                           |
-      | fields              | burgerservicenummer,nationaliteiten |
-      Dan heeft de persoon met burgerservicenummer '555550002' een 'nationaliteit' met de volgende gegevens
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550002                       |
+      | fields              | nationaliteiten                 |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
       | naam               | waarde        |
       | type               | Nationaliteit |
       | nationaliteit.code | 0263          |
@@ -220,11 +219,11 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       | naam               | waarde |
       | nationaliteit.code | 0499   |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                              |
-      | type                | RaadpleegMetBurgerservicenummer     |
-      | burgerservicenummer | 555550002                           |
-      | fields              | burgerservicenummer,nationaliteiten |
-      Dan heeft de persoon met burgerservicenummer '555550002' een 'nationaliteit' met de volgende gegevens
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550002                       |
+      | fields              | nationaliteiten                 |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
       | naam               | waarde        |
       | type               | Nationaliteit |
       | nationaliteit.code | 0499          |
@@ -238,11 +237,11 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       | naam               | waarde |
       | nationaliteit.code | 0000   |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                              |
-      | type                | RaadpleegMetBurgerservicenummer     |
-      | burgerservicenummer | 999993367                           |
-      | fields              | burgerservicenummer,nationaliteiten |
-      Dan heeft de persoon met burgerservicenummer '999993367' een 'nationaliteit' met de volgende gegevens
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999993367                       |
+      | fields              | nationaliteiten                 |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
       | naam | waarde                |
       | type | NationaliteitOnbekend |
 
@@ -255,11 +254,11 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       | naam                                     | waarde |
       | aanduidingBijzonderNederlanderschap.code | B      |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                              |
-      | type                | RaadpleegMetBurgerservicenummer     |
-      | burgerservicenummer | 000009866                           |
-      | fields              | burgerservicenummer,nationaliteiten |
-      Dan heeft de persoon met burgerservicenummer '000009866' een 'nationaliteit' met de volgende gegevens
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000009866                       |
+      | fields              | nationaliteiten                 |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
       | naam | waarde                  |
       | type | BehandeldAlsNederlander |
 
@@ -272,10 +271,10 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       | naam                                     | waarde |
       | aanduidingBijzonderNederlanderschap.code | V      |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                              |
-      | type                | RaadpleegMetBurgerservicenummer     |
-      | burgerservicenummer | 999994748                           |
-      | fields              | burgerservicenummer,nationaliteiten |
-      Dan heeft de persoon met burgerservicenummer '999994748' een 'nationaliteit' met de volgende gegevens
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999994748                       |
+      | fields              | nationaliteiten                 |
+      Dan heeft de response een persoon met een 'nationaliteit' met de volgende gegevens
       | naam | waarde                     |
       | type | VastgesteldNietNederlander |

--- a/features/nationaliteit.feature
+++ b/features/nationaliteit.feature
@@ -183,6 +183,7 @@ Functionaliteit: Bepalen van de actuele nationaliteit van een persoon
       En de persoon heeft een 'nationaliteit' met de volgende gegevens
       | naam               | waarde |
       | nationaliteit.code | 0001   |
+      Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 000009830                       |

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -1030,7 +1030,7 @@
         "example" : "20180700"
       },
       "GbaInOnderzoek" : {
-        "required" : [ "aanduidingGegevensInOnderzoek", "datumIngangInOnderzoek" ],
+        "required" : [ "aanduidingGegevensInOnderzoek", "datumIngangOnderzoek" ],
         "type" : "object",
         "properties" : {
           "aanduidingGegevensInOnderzoek" : {

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -821,7 +821,7 @@ components:
     GbaInOnderzoek:
       required:
       - aanduidingGegevensInOnderzoek
-      - datumIngangInOnderzoek
+      - datumIngangOnderzoek
       type: object
       properties:
         aanduidingGegevensInOnderzoek:

--- a/specificatie/gba-inonderzoek.yaml
+++ b/specificatie/gba-inonderzoek.yaml
@@ -10,7 +10,7 @@ components:
       type: object
       required:
         - aanduidingGegevensInOnderzoek
-        - datumIngangInOnderzoek
+        - datumIngangOnderzoek
       properties:
         aanduidingGegevensInOnderzoek:
           type: string

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -1419,6 +1419,9 @@
         }, {
           "type" : "object",
           "properties" : {
+            "type" : {
+              "type" : "boolean"
+            },
             "nationaliteit" : {
               "type" : "boolean"
             },

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -1109,6 +1109,8 @@ components:
       - $ref: '#/components/schemas/InOnderzoek'
       - type: object
         properties:
+          type:
+            type: boolean
           nationaliteit:
             type: boolean
           redenOpname:

--- a/specificatie/nationaliteit.yaml
+++ b/specificatie/nationaliteit.yaml
@@ -96,6 +96,8 @@ components:
         - $ref: 'persoon.yaml#/components/schemas/InOnderzoek'
         - type: object
           properties:
+            type:
+              type: boolean
             nationaliteit:
               type: boolean
             redenOpname:


### PR DESCRIPTION
- nationaliteit is in onderzoek scenario's aangepast
  - volgens de OAS heeft alleen de Nationaliteit type een inOnderzoek.nationaliteit property
  - nationaliteit type toegevoegd in dan stap ivm verplicht zijn van deze property
  - nationaliteit kolom komt 2 keer voor
- nationaliteit.feature aangepast tbv consistentie en automation
- typo in gba-inonderzoek.yaml gecorrigeerd
- ontbrekende 'type' property toegevoegd aan NationaliteitInOnderzoek

vraag: wat is een EU-persoonsnummer voor nationaliteit? Deze komt niet voor in de nationaliteiten waarde tabel