### PR TITLE
Definitie van Waardetabel

### DIFF
--- a/specificatie/geboorte.yaml
+++ b/specificatie/geboorte.yaml
@@ -17,7 +17,9 @@ components:
         - type: object
           properties:
             land:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             plaats:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
     GeboorteBeperkt:
@@ -36,7 +38,9 @@ components:
         - type: object
           properties:
             land:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             plaats:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             inOnderzoek:

--- a/specificatie/gezagsverhouding.yaml
+++ b/specificatie/gezagsverhouding.yaml
@@ -17,7 +17,9 @@ components:
             Geeft aan dat de persoon onder curatele is gesteld.
           example: true
         indicatieGezagMinderjarige:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van indicatieGezagMinderjarige wordt de tabel met identificatie "gezag_minderjarige" opgehaald m.b.v. "BRP tabellen bevragen"-API.
     GbaGezagsverhouding:
       allOf:
         - $ref: '#/components/schemas/GezagsverhoudingBasis'

--- a/specificatie/naam.yaml
+++ b/specificatie/naam.yaml
@@ -70,7 +70,7 @@ components:
     AdellijkeTitelPredicaatType:
       allOf:
         - $ref: 'common.yaml#/components/schemas/Waardetabel'
-        - description: Voor de enumeratie van adellijkeTitelPredicaat wordt tabel 38 met identificatie "Adellijke titel/predicaat" opgehaald m.b.v. "BRP tabellen bevragen"-API.
+        - description: Voor de enumeratie van adellijkeTitelPredicaat wordt tabel 38 met identificatie "Adellijke titel/predicaat" opgehaald m.b.v. "BRP tabellen bevragen"-API. Met de property 'soort' wordt aangegeven of het een 'predicaat' of een 'titel' betreft. 
           properties:
             soort:
               $ref: '#/components/schemas/AdellijkeTitelPredicaatSoort'

--- a/specificatie/naam.yaml
+++ b/specificatie/naam.yaml
@@ -70,7 +70,8 @@ components:
     AdellijkeTitelPredicaatType:
       allOf:
         - $ref: 'common.yaml#/components/schemas/Waardetabel'
-        - properties:
+        - description: Voor de enumeratie van adellijkeTitelPredicaat wordt tabel 38 met identificatie "Adellijke titel/predicaat" opgehaald m.b.v. "BRP tabellen bevragen"-API.
+          properties:
             soort:
               $ref: '#/components/schemas/AdellijkeTitelPredicaatSoort'
           example:
@@ -94,7 +95,9 @@ components:
         - $ref: '#/components/schemas/GbaNaamBasis'
         - properties:
             aanduidingNaamgebruik:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van aanduidingNaamgebruik wordt de tabel met identificatie "naamgebruik" opgehaald m.b.v. "BRP tabellen bevragen"-API.
     NaamBasis:
       type: object
       properties:
@@ -147,7 +150,9 @@ components:
         - $ref: '#/components/schemas/NaamBasis'
         - properties:
             aanduidingNaamgebruik:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van aanduidingNaamgebruik wordt de tabel met identificatie "naamgebruik" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             aanhef:
               $ref: '#/components/schemas/Aanhef'
             aanschrijfwijze:

--- a/specificatie/nationaliteit.yaml
+++ b/specificatie/nationaliteit.yaml
@@ -32,7 +32,9 @@ components:
             datumIngangGeldigheid:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             nationaliteit:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van land wordt tabel 32 met identificatie "Nationaliteiten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             inOnderzoek:
               $ref: '#/components/schemas/NationaliteitInOnderzoek'
     BehandeldAlsNederlander:
@@ -75,7 +77,9 @@ components:
         datumIngangGeldigheid:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
         nationaliteit:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van land wordt tabel 32 met identificatie "Nationaliteiten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         redenOpname:
           $ref: 'common.yaml#/components/schemas/Waardetabel'
         inOnderzoek:

--- a/specificatie/opschortingbijhouding.yaml
+++ b/specificatie/opschortingbijhouding.yaml
@@ -12,7 +12,9 @@ components:
         * **reden** - wordt gevuld op basis van de waarden die voorkomen in de tabel 'redenopschortingbijhouding' uit de Haal-Centraal-BRP-tabellen-bevragen API.
       properties:
         reden:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "redenopschortingbijhouding" opgehaald m.b.v. "BRP tabellen bevragen"-API.
     GbaOpschortingBijhouding:
       allOf:
         - $ref: '#/components/schemas/OpschortingBijhoudingBasis'

--- a/specificatie/ouder.yaml
+++ b/specificatie/ouder.yaml
@@ -33,7 +33,9 @@ components:
         burgerservicenummer:
           $ref: 'persoon.yaml#/components/schemas/Burgerservicenummer'
         geslachtsaanduiding:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         ouderAanduiding:
           $ref: '#/components/schemas/OuderAanduiding'
         datumIngangFamilierechtelijkeBetrekking:
@@ -56,7 +58,9 @@ components:
             burgerservicenummer:
               $ref: 'persoon.yaml#/components/schemas/Burgerservicenummer'
             geslachtsaanduiding:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             ouderAanduiding:
               $ref: '#/components/schemas/OuderAanduiding'
             datumIngangFamilierechtelijkeBetrekking:

--- a/specificatie/overlijden.yaml
+++ b/specificatie/overlijden.yaml
@@ -21,7 +21,9 @@ components:
         - type: object
           properties:
             land:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             plaats:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             inOnderzoek:
@@ -44,7 +46,9 @@ components:
             datum:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             land:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             plaats:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             inOnderzoek:

--- a/specificatie/partner.yaml
+++ b/specificatie/partner.yaml
@@ -26,9 +26,13 @@ components:
         burgerservicenummer:
           $ref: 'persoon.yaml#/components/schemas/Burgerservicenummer'
         geslachtsaanduiding:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         soortVerbintenis:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van soortVerbintenis wordt tabel 34 met identificatie "soort_verbintenis" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         naam:
           $ref: 'naam.yaml#/components/schemas/GbaNaamBasis'
         geboorte:
@@ -47,9 +51,13 @@ components:
             burgerservicenummer:
               $ref: 'persoon.yaml#/components/schemas/Burgerservicenummer'
             geslachtsaanduiding:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             soortVerbintenis:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van soortVerbintenis wordt tabel 34 met identificatie "soort_verbintenis" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             naam:
               $ref: 'naam.yaml#/components/schemas/NaamGerelateerde'
             geboorte:
@@ -91,8 +99,10 @@ components:
         datum:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
         land:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
-        plaats:
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
+       plaats:
           $ref: 'common.yaml#/components/schemas/Waardetabel'
         inOnderzoek:
           $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
@@ -107,7 +117,9 @@ components:
         datum:
           $ref: 'datum.yaml#/components/schemas/AbstractDatum'
         land:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         plaats:
           $ref: 'common.yaml#/components/schemas/Waardetabel'
         inOnderzoek:

--- a/specificatie/persoon.yaml
+++ b/specificatie/persoon.yaml
@@ -44,7 +44,9 @@ components:
         geheimhoudingPersoonsgegevens:
           $ref: '#/components/schemas/GbaGeheimhoudingPersoonsgegevens'
         geslachtsaanduiding:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         naam:
           $ref: 'naam.yaml#/components/schemas/GbaNaamBasis'
         opschortingBijhouding:
@@ -63,7 +65,9 @@ components:
         geheimhoudingPersoonsgegevens:
           $ref: '#/components/schemas/GeheimhoudingPersoonsgegevens'
         geslachtsaanduiding:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         leeftijd:
           $ref: '#/components/schemas/Leeftijd'
         naam:
@@ -86,7 +90,9 @@ components:
         geheimhoudingPersoonsgegevens:
           $ref: '#/components/schemas/GbaGeheimhoudingPersoonsgegevens'
         geslachtsaanduiding:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         inOnderzoek:
           $ref: 'gba-inonderzoek.yaml#/components/schemas/GbaInOnderzoek'
         kiesrecht:
@@ -137,7 +143,9 @@ components:
         geheimhoudingPersoonsgegevens:
           $ref: '#/components/schemas/GeheimhoudingPersoonsgegevens'
         geslachtsaanduiding:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van de geslachtsaanduiding wordt de tabel met identificatie "geslacht" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         inOnderzoek:
           $ref: '#/components/schemas/PersoonInOnderzoek'
         kiesrecht:

--- a/specificatie/verblijfplaats.yaml
+++ b/specificatie/verblijfplaats.yaml
@@ -128,7 +128,9 @@ components:
         - type: object
           properties:
             functieAdres:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van functieAdres wordt de tabel met identificatie "soort_adres" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             adresregel1:
               $ref: '#/components/schemas/Adresregel1'
             adresregel2:
@@ -147,7 +149,9 @@ components:
             adresregel3:
               $ref: '#/components/schemas/Adresregel3'
             land:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
     VerblijfplaatsOnbekendBeperkt:
       allOf:
         - $ref: '#/components/schemas/AbstractVerblijfplaatsBeperkt'
@@ -165,7 +169,9 @@ components:
             adresregel2:
               $ref: '#/components/schemas/Adresregel2'
             functieAdres:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van functieAdres wordt de tabel met identificatie "soort_adres" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             locatiebeschrijving:
               $ref: '#/components/schemas/Locatiebeschrijving'
             woonplaats:
@@ -174,7 +180,9 @@ components:
       type: object
       properties:
         functieAdres:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van functieAdres wordt de tabel met identificatie "soort_adres" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         woonplaats:
           $ref: '#/components/schemas/Woonplaats'
         straat:
@@ -186,15 +194,21 @@ components:
         huisnummertoevoeging:
           $ref: '#/components/schemas/Huisnummertoevoeging'
         aanduidingBijHuisnummer:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van aanduidingBijHuisnummer wordt de tabel met identificatie "aanduidingbijhuisnummer" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         postcode:
           $ref: '#/components/schemas/Postcode'
         locatiebeschrijving:
           $ref: '#/components/schemas/Locatiebeschrijving'
         land:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         gemeenteVanInschrijving:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van gemeenteVanInschrijving wordt tabel 33 met identificatie "Gemeenten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         adresregel1:
           $ref: '#/components/schemas/Adresregel1'
         adresregel2:
@@ -231,9 +245,13 @@ components:
           datumInschrijvingInGemeente:
             $ref: 'datum.yaml#/components/schemas/AbstractDatum'
           gemeenteVanInschrijving:
-            $ref: 'common.yaml#/components/schemas/Waardetabel'
+            allOf:
+            - $ref: 'common.yaml#/components/schemas/Waardetabel'
+            - description: Voor de enumeratie van gemeenteVanInschrijving wordt tabel 33 met identificatie "Gemeenten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
           land:
-            $ref: 'common.yaml#/components/schemas/Waardetabel'
+            allOf:
+            - $ref: 'common.yaml#/components/schemas/Waardetabel'
+            - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
           datumVan:
             $ref: 'datum.yaml#/components/schemas/AbstractDatum'
           datumIngangGeldigheid:
@@ -254,7 +272,9 @@ components:
         - type: object
           properties:
             functieAdres:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van functieAdres wordt de tabel met identificatie "soort_adres" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             straat:
               $ref: '#/components/schemas/Straat'
             huisnummer:
@@ -264,7 +284,9 @@ components:
             huisnummertoevoeging:
               $ref: '#/components/schemas/Huisnummertoevoeging'
             aanduidingBijHuisnummer:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van aanduidingBijHuisnummer wordt de tabel met identificatie "aanduidingbijhuisnummer" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             postcode:
               $ref: '#/components/schemas/Postcode'
             adresseerbaarObjectIdentificatie:
@@ -292,9 +314,13 @@ components:
             datumVestigingInNederland:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             gemeenteVanInschrijving:
-              $ref: "common.yaml#/components/schemas/Waardetabel"
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van gemeenteVanInschrijving wordt tabel 33 met identificatie "Gemeenten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             landVanwaarIngeschreven:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van landVanwaarIngeschreven wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             inOnderzoek:
               $ref: "#/components/schemas/AdresInOnderzoek"
     Locatie:
@@ -313,13 +339,19 @@ components:
             datumVan:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             functieAdres:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van functieAdres wordt de tabel met identificatie "soort_adres" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             gemeenteVanInschrijving:
-              $ref: "common.yaml#/components/schemas/Waardetabel"
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van gemeenteVanInschrijving wordt tabel 33 met identificatie "Gemeenten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             indicatieVestigingVanuitBuitenland:
               $ref: '#/components/schemas/IndicatieVestigingVanuitBuitenland'
             landVanwaarIngeschreven:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van landVanwaarIngeschreven wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             locatiebeschrijving:
               $ref: '#/components/schemas/Locatiebeschrijving'
             vanuitVerblijfplaatsOnbekend:
@@ -336,7 +368,9 @@ components:
             datumInschrijvingInGemeente:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             gemeenteVanInschrijving:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
+              allOf:
+              - $ref: 'common.yaml#/components/schemas/Waardetabel'
+              - description: Voor de enumeratie van gemeenteVanInschrijving wordt tabel 33 met identificatie "Gemeenten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
             verblijfplaatsOnbekend:
               $ref: '#/components/schemas/IndicatieVerblijfplaatsOnbekend'
             inOnderzoek:
@@ -355,11 +389,15 @@ components:
         nummeraanduidingIdentificatie:
           $ref: '#/components/schemas/NummeraanduidingIdentificatie'
         functieAdres:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van functieAdres wordt de tabel met identificatie "soort_adres" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         woonplaats:
           $ref: '#/components/schemas/Woonplaats'
         landVanwaarIngeschreven:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van landVanwaarIngeschreven wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         straat:
           $ref: '#/components/schemas/Straat'
         huisnummer:
@@ -369,13 +407,17 @@ components:
         huisnummertoevoeging:
           $ref: '#/components/schemas/Huisnummertoevoeging'
         aanduidingBijHuisnummer:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van aanduidingBijHuisnummer wordt de tabel met identificatie "aanduidingbijhuisnummer" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         postcode:
           $ref: '#/components/schemas/Postcode'
         locatiebeschrijving:
           $ref: '#/components/schemas/Locatiebeschrijving'
         land:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van land wordt tabel 34 met identificatie "Landen" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         datumAanvangAdreshouding:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
         datumAanvangAdresBuitenland:
@@ -387,7 +429,9 @@ components:
         datumVestigingInNederland:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
         gemeenteVanInschrijving:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          allOf:
+          - $ref: 'common.yaml#/components/schemas/Waardetabel'
+          - description: Voor de enumeratie van gemeenteVanInschrijving wordt tabel 33 met identificatie "Gemeenten" opgehaald m.b.v. "BRP tabellen bevragen"-API.
         naamOpenbareRuimte:
           $ref: '#/components/schemas/NaamOpenbareRuimte'
         inOnderzoek:


### PR DESCRIPTION
Fixes https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/issues/1006

Bij elk veld dat gedefinieerd is als Waardetabel  is m.b.v. een 'description' property aangeven welke tabel gebruikt moet worden m.b.v. de "BRP tabellen bevragen"-API.

Enkele opmerkingen:
* Bij de bestaande tabellen is in de description ook het tabelnummer opgenomen.
* De naamgeving van de bestaande tabellen hebben een andere naamgevingsconventie. Misschien goed om de nieuwe tabellen daarbij aan te laten sluiten:
   * Namen van de bestaande tabellen starten met een hoofdletter;
   * In de namen van de bestaande tabellen komen spaties en speciale karakters voor (bijv. 'Reden opnemen/beëindigen nationaliteit'). Hieronder een voorstel voor aangepaste naamgeving:

| Oude naam | Nieuwe naam |
| --- | --- |
| aanduidingbijhuisnummer | Aanduiding bij huisnummer |
| geslacht | Geslacht |
| naamgebruik | Naamgebruik |
| redenopschortingbijhouding | Reden opschorting/bijhouding |
| soort_verbintenis | Soort verbintenis |
| soort_adres | Soort adres (of juist 'Functie adres' zodat het aansluit bij de naam van de gebruikende property) |
| gezag_minderjarige | Gezag minderjarige |
* Met het aanbrengen van de aanpassingen komen er soms AllOf constructies binnen AllOf constructies voor. Wellicht is dat een reden om daar een apart component aan te maken. Dit doet zich voor in de volgende componenten:
   * VerblijfplaatsBuitenlandBeperkt
   * AdresBeperkt
   * LocatieBeperkt
   * NaamPersoon
   * Nationaliteit
   * Geboorte
   * Overlijden
   * VerblijfplaatsBuitenland
   * Adres
   * VerblijfplaatsOnbekend
   * Locatie
   * Ouder
   * Partner
* Voor de volgende gevallen bestaat nog geen tabel (geen bestaande en ook geen nieuwe in tabelwaarden.feature):
   * 'redenOpname' (in AbstractNationaliteit)
   * 'aanduiding' (in Verblijfstitel) 
   * 'aanduidingBijzonderNederlanderschap' (in GbaNationaliteit)
* Kan bij de property 'plaats' (in bijv. het component 'Geboorte') gebruik gemaakt worden van de waardetabel 'Gemeenten' of is toch een aparte waardetabel nodig?
* Aangezien in het component 'AdellijkeTitelPredicaatType' naast een referentie naar een Waardetabel ook nog de property 'soort' is gedefinieerd ben ik zo vrij geweest de description zo aan te passen dat deze op alle properties betrekking heeft.