### PR TITLE
fix(specs): aanhef feature

### DIFF
--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -649,7 +649,7 @@ Rule: Voor het bepalen van de aanhef gaat gebruik van de adellijke titel van de 
 
 Rule: Bij meerdere actuele (niet ontbonden) huwelijken/partnerschappen worden de naamgegevens van de eerste partner (oudste relatie) gebruikt voor het samenstellen van de aanhef
 
-  Scenario: meerdere actuele relaties
+  Abstract Scenario: meerdere actuele relaties
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
@@ -660,38 +660,41 @@ Rule: Bij meerdere actuele (niet ontbonden) huwelijken/partnerschappen worden de
     | geslachtsnaam (02.40)          | Groen              |
     | voornamen (02.10)              | Ferdinand Cornelis |
     | aanduiding naamgebruik (61.10) | V                  |
-    En de persoon heeft een 'partner' met de volgende gegevens
-    | naam                | waarde    |
-    | burgerservicenummer | 999992935 |
-    En de 'partner' heeft de volgende 'naam' gegevens
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Geel   |
     En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
-    | naam                                                               | waarde   |
-    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19580401 |
-    En de persoon heeft een 'partner' met de volgende gegevens
-    | naam                | waarde    |
-    | burgerservicenummer | 999992936 |
-    En de 'partner' heeft de volgende 'naam' gegevens
+    | naam                                                               | waarde            |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | <datum partner 1> |
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Roodt  |
     En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
-    | naam                                                               | waarde   |
-    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19610808 |
+    | naam                                                               | waarde            |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | <datum partner 2> |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
     Dan heeft de response een persoon met de volgende 'naam' gegevens
-    | naam   | waarde                     |
-    | aanhef | Geachte mevrouw Geel-Groen |
+    | naam   | waarde                 |
+    | aanhef | Geachte mevrouw <naam> |
+
+    Voorbeelden:
+    | datum partner 1 | datum partner 2 | naam        | omschrijving                                                                                                                      |
+    | 19580401        | 19610808        | Geel-Groen  |                                                                                                                                   |
+    | 19580401        | 19610800        | Geel-Groen  |                                                                                                                                   |
+    | 19580401        | 19610000        | Geel-Groen  |                                                                                                                                   |
+    | 19580401        | 00000000        | Roodt-Groen | partner met datum onbekend wordt eerste partner                                                                                   |
+    | 19610800        | 19610808        | Geel-Groen  | jaar en maand zijn bekend en zijn gelijk, partner met dag onbekend wordt eerste partner                                           |
+    | 19610000        | 19610800        | Geel-Groen  | partner 1 alleen jaar bekend, partner 2 jaar en maand bekend, jaar gelijk, partner met maand en dag onbekend wordt eerste partner |
 
 Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden de naamgegevens van de laatst ontbonden partner gebruikt voor het samenstellen van de aanhef
 
-  Scenario: meerdere ontbonden relaties gebruikt de laatst ontbonden relatie
+  Abstract Scenario: meerdere ontbonden relaties gebruikt de laatst ontbonden relatie
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
@@ -702,10 +705,7 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     | geslachtsnaam (02.40)          | Wit    |
     | voornamen (02.10)              | Jan    |
     | aanduiding naamgebruik (61.10) | V      |
-    En de persoon heeft een 'partner' met de volgende gegevens
-    | naam                | waarde    |
-    | burgerservicenummer | 999992935 |
-    En de 'partner' heeft de volgende 'naam' gegevens
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Geel   |
@@ -713,12 +713,9 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     | naam                                                               | waarde   |
     | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19580401 |
     En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
-    | naam                                                         | waarde   |
-    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 19601001 |
-    En de persoon heeft een 'partner' met de volgende gegevens
-    | naam                | waarde    |
-    | burgerservicenummer | 999992936 |
-    En de 'partner' heeft de volgende 'naam' gegevens
+    | naam                                                         | waarde            |
+    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | <datum partner 1> |
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Roodt  |
@@ -726,8 +723,8 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     | naam                                                               | waarde   |
     | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19610422 |
     En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
-    | naam                                                         | waarde   |
-    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20061014 |
+    | naam                                                         | waarde            |
+    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | <datum partner 2> |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -736,6 +733,15 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde                    |
     | aanhef | Geachte mevrouw Roodt-Wit |
+
+    Voorbeelden:
+    | datum partner 1 | datum partner 2 |
+    | 19601001        | 20061014        |
+    | 19601000        | 20061014        |
+    | 19600000        | 20061014        |
+    | 00000000        | 20061014        |
+    | 20061000        | 20061014        |
+    | 20060000        | 20061000        |
 
   Scenario: meerdere ontbonden relaties en oudste relatie is het laatst ontbonden
     Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -748,10 +754,7 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     | geslachtsnaam (02.40)          | Wit    |
     | voornamen (02.10)              | Jan    |
     | aanduiding naamgebruik (61.10) | V      |
-    En de persoon heeft een 'partner' met de volgende gegevens
-    | naam                | waarde    |
-    | burgerservicenummer | 999992935 |
-    En de 'partner' heeft de volgende 'naam' gegevens
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Zwart  |
@@ -761,10 +764,7 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
     | naam                                                         | waarde   |
     | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20061001 |
-    En de persoon heeft een 'partner' met de volgende gegevens
-    | naam                | waarde    |
-    | burgerservicenummer | 999992936 |
-    En de 'partner' heeft de volgende 'naam' gegevens
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Blaauw |

--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -1,7 +1,7 @@
 # language: nl
 
 # Issue #334 en #337
-@proxy
+@proxy @post-assert
 Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in communicatie naar burgers
   De aanhef bij een persoon wordt gevuld door de provider om op deze wijze op eenduidige wijze een persoon te kunnen aanschrijven.
   De aanhef wordt gebruikt bovenaan een brief.
@@ -35,7 +35,7 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde  |
     | voornamen (02.10)                    | Jo Rene |
     | adellijke titel of predicaat (02.20) |         |
@@ -47,7 +47,7 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -62,7 +62,7 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde                  |
     | adellijke titel of predicaat (02.20) |                         |
     | voorvoegsel (02.30)                  | in het                  |
@@ -74,7 +74,7 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde                      |
     | aanhef | Geachte mevrouw In het Veld |
 
@@ -90,16 +90,16 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde          |
     | adellijke titel of predicaat (02.20) |                 |
     | voorvoegsel (02.30)                  | <voorvoegsel>   |
     | geslachtsnaam (02.40)                | <geslachtsnaam> |
     | aanduiding naamgebruik (61.10)       | <naamgebruik>   |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde                  |
     | adellijke titel of predicaat (02.20) |                         |
     | voorvoegsel (02.30)                  | <partner voorvoegsel>   |
@@ -109,7 +109,7 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -118,9 +118,9 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | E           | in het      | Veld          | van                 | Velzen                | Geachte mevrouw In het Veld            |
     | E           |             | Groenen       |                     | Groenink              | Geachte mevrouw Groenen                |
     | P           | in het      | Veld          | van                 | Velzen                | Geachte mevrouw Van Velzen             |
-    | P           |             | Groenen       |                     | Groenink              | Geachte mevrouw Groenen                |
+    | P           |             | Groenen       |                     | Groenink              | Geachte mevrouw Groenink               |
     | V           | in het      | Veld          | van                 | Velzen                | Geachte mevrouw Van Velzen-in het Veld |
-    | V           |             | Groenen       |                     | Groenink              | Geachte mevrouw Groenen-Groenink       |
+    | V           |             | Groenen       |                     | Groenink              | Geachte mevrouw Groenink-Groenen       |
     | N           | in het      | Veld          | van                 | Velzen                | Geachte mevrouw In het Veld-van Velzen |
     | N           |             | Groenen       |                     | Groenink              | Geachte mevrouw Groenen-Groenink       |
 
@@ -129,17 +129,17 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde          |
     | voornamen (02.10)                    | <voornamen>     |
     | adellijke titel of predicaat (02.20) |                 |
     | voorvoegsel (02.30)                  | <voorvoegsel>   |
     | geslachtsnaam (02.40)                | <geslachtsnaam> |
     | aanduiding naamgebruik (61.10)       | <naamgebruik>   |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde                  |
     | adellijke titel of predicaat (02.20) |                         |
     | voorvoegsel (02.30)                  | <partner voorvoegsel>   |
@@ -149,7 +149,7 @@ Rule: De aanhef voor een persoon zonder adellijke titel of predicaat wordt samen
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -217,17 +217,17 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde                    |
     | voornamen (02.10)                    | Pieter                    |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat> |
     | voorvoegsel (02.30)                  | van den                   |
     | geslachtsnaam (02.40)                | Aedel                     |
     | aanduiding naamgebruik (61.10)       | E                         |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
@@ -237,7 +237,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -270,17 +270,17 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | M         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde                    |
     | voornamen (02.10)                    | Pieter                    |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat> |
     | voorvoegsel (02.30)                  | van den                   |
     | geslachtsnaam (02.40)                | Aedel                     |
     | aanduiding naamgebruik (61.10)       | <naamgebruik>             |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
@@ -290,7 +290,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -306,17 +306,17 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde  |
     | voornamen (02.10)                    | Pieter  |
     | adellijke titel of predicaat (02.20) | JV      |
     | voorvoegsel (02.30)                  | van den |
     | geslachtsnaam (02.40)                | Aedel   |
     | aanduiding naamgebruik (61.10)       | E       |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
@@ -326,32 +326,32 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
     Voorbeelden:
-      | geslacht | aanhef                        |
-      | M        | Hoogwelgeboren heer           |
-      | V        | Geachte mevrouw Van den Aedel |
-      | O        | Geachte P. van den Aedel      |
+      | geslacht | aanhef                   |
+      | M        | Hoogwelgeboren heer      |
+      | V        | Hoogwelgeboren vrouwe    |
+      | O        | Geachte P. van den Aedel |
 
   Abstract Scenario: persoon met partner heeft predicaat en naamgebruik "<naamgebruik>"
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | M         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde        |
     | voornamen (02.10)                    | Pieter        |
     | adellijke titel of predicaat (02.20) | JH            |
     | voorvoegsel (02.30)                  | van den       |
     | geslachtsnaam (02.40)                | Aedel         |
     | aanduiding naamgebruik (61.10)       | <naamgebruik> |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
@@ -361,7 +361,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -377,7 +377,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde        |
     | voornamen (02.10)                    | Pieter        |
     | adellijke titel of predicaat (02.20) | JH            |
@@ -385,15 +385,15 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | geslachtsnaam (02.40)                | Aedel         |
     | aanduiding naamgebruik (61.10)       | <naamgebruik> |
     En de persoon heeft geen actuele partner
-    En de persoon heeft een ex-partner met de volgende gegevens
+    En de persoon heeft een 'ex-partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de ex-partner heeft de volgende 'naam' gegevens
+    En de 'ex-partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
     | geslachtsnaam (02.40)                | Boer   |
-    En de ex-partner heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+    En de 'ex-partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
     | naam                     | waarde   |
     | datum ontbinding (07.10) | 20211109 |
     Als personen wordt gezocht met de volgende parameters
@@ -401,7 +401,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -437,17 +437,17 @@ Rule: De aanhef voor een persoon wordt bepaald door het adellijkeTitelPredicaat 
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | voornamen (02.10)                    | Jo     |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
     | geslachtsnaam (02.40)                | Boer   |
     | aanduiding naamgebruik (61.10)       | P      |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde                            |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat partner> |
     | voorvoegsel (02.30)                  | van den                           |
@@ -457,7 +457,7 @@ Rule: De aanhef voor een persoon wordt bepaald door het adellijkeTitelPredicaat 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -478,17 +478,17 @@ Rule: De aanhef voor een persoon wordt bepaald door het adellijkeTitelPredicaat 
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | voornamen (02.10)                    | Jo     |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
     | geslachtsnaam (02.40)                | Boer   |
     | aanduiding naamgebruik (61.10)       | P      |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde          |
     | adellijke titel of predicaat (02.20) | <titel partner> |
     | voorvoegsel (02.30)                  | van den         |
@@ -498,7 +498,7 @@ Rule: De aanhef voor een persoon wordt bepaald door het adellijkeTitelPredicaat 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -516,17 +516,17 @@ Rule: De aanhef voor een persoon wordt bepaald door het adellijkeTitelPredicaat 
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde        |
     | voornamen (02.10)                    | Jo            |
     | adellijke titel of predicaat (02.20) |               |
     | voorvoegsel (02.30)                  | de            |
     | geslachtsnaam (02.40)                | Boer          |
     | aanduiding naamgebruik (61.10)       | <naamgebruik> |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde  |
     | adellijke titel of predicaat (02.20) | B       |
     | voorvoegsel (02.30)                  | van den |
@@ -536,7 +536,7 @@ Rule: De aanhef voor een persoon wordt bepaald door het adellijkeTitelPredicaat 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -562,18 +562,18 @@ Rule: Voor het bepalen van de aanhef gaat gebruik van de adellijke titel van de 
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
-    | naam                                 | waarde        |
-    | voornamen (02.10)                    | Jo            |
-    | adellijke titel of predicaat (02.20) |               |
-    | voorvoegsel (02.30)                  | van den       |
-    | geslachtsnaam (02.40)                | Aedel         |
-    | aanduiding naamgebruik (61.10)       | <naamgebruik> |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft de volgende 'naam' gegevens
+    | naam                                 | waarde                    |
+    | voornamen (02.10)                    | Jo                        |
+    | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat> |
+    | voorvoegsel (02.30)                  | van den                   |
+    | geslachtsnaam (02.40)                | Aedel                     |
+    | aanduiding naamgebruik (61.10)       | <naamgebruik>             |
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992935 |
     | geslachtsaanduiding (04.10) | M         |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde                            |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat partner> |
     | voorvoegsel (02.30)                  | de                                |
@@ -583,46 +583,46 @@ Rule: Voor het bepalen van de aanhef gaat gebruik van de adellijke titel van de 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
     Voorbeelden:
-      | adellijkeTitelPredicaat | adellijkeTitelPredicaat partner | naamgebruik | aanhef                  |
-      | GI                      | B                               | E           | Hooggeboren vrouwe      |
-      | GI                      | B                               | P           | Hoogwelgeboren vrouwe   |
-      | GI                      | B                               | V           | Hoogwelgeboren vrouwe   |
-      | GI                      | B                               | N           | Hoogwelgeboren vrouwe   |
-      | BS                      | P                               | E           | Hoogwelgeboren vrouwe   |
-      | BS                      | P                               | P           | Hoogheid                |
-      | BS                      | P                               | V           | Hoogheid                |
-      | BS                      | P                               | N           | Hoogheid                |
-      | GI                      | R                               | E           | Hooggeboren vrouwe      |
-      | GI                      | R                               | P           | Geachte mevrouw De Boer |
-      | GI                      | R                               | V           | Hooggeboren vrouwe      |
-      | GI                      | R                               | P           | Hooggeboren vrouwe      |
-      | PS                      | B                               | E           | Hoogheid                |
-      | PS                      | B                               | P           | Hoogwelgeboren vrouwe   |
-      | PS                      | B                               | V           | Hoogwelgeboren vrouwe   |
-      | PS                      | B                               | N           | Hoogwelgeboren vrouwe   |
+      | adellijkeTitelPredicaat | adellijkeTitelPredicaat partner | naamgebruik | aanhef                                |
+      | GI                      | B                               | E           | Hooggeboren vrouwe                    |
+      | GI                      | B                               | P           | Hoogwelgeboren vrouwe                 |
+      | GI                      | B                               | V           | Hoogwelgeboren vrouwe                 |
+      | GI                      | B                               | N           | Hoogwelgeboren vrouwe                 |
+      | BS                      | P                               | E           | Hoogwelgeboren vrouwe                 |
+      | BS                      | P                               | P           | Hoogheid                              |
+      | BS                      | P                               | V           | Hoogheid                              |
+      | BS                      | P                               | N           | Hoogheid                              |
+      | GI                      | R                               | E           | Hooggeboren vrouwe                    |
+      | GI                      | R                               | P           | Geachte mevrouw De Boer               |
+      | GI                      | R                               | V           | Geachte mevrouw De Boer-van den Aedel |
+      | GI                      | R                               | N           | Geachte mevrouw Van den Aedel-de Boer |
+      | PS                      | B                               | E           | Hoogheid                              |
+      | PS                      | B                               | P           | Hoogwelgeboren vrouwe                 |
+      | PS                      | B                               | V           | Hoogwelgeboren vrouwe                 |
+      | PS                      | B                               | N           | Hoogwelgeboren vrouwe                 |
 
   Abstract Scenario: man heeft adellijke titel <adellijkeTitelPredicaat> en zijn partner heeft adellijke titel "<adellijkeTitelPredicaat partner>" bij aanduidingNaamgebruik "<naamgebruik>"
     Gegeven het systeem heeft een persoon met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | M         |
-    En de persoon heeft de volgende naam gegevens
-    | naam                                 | waarde        |
-    | voornamen (02.10)                    | Jo            |
-    | adellijke titel of predicaat (02.20) |               |
-    | voorvoegsel (02.30)                  | van den       |
-    | geslachtsnaam (02.40)                | Aedel         |
-    | aanduiding naamgebruik (61.10)       | <naamgebruik> |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft de volgende 'naam' gegevens
+    | naam                                 | waarde                    |
+    | voornamen (02.10)                    | Jo                        |
+    | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat> |
+    | voorvoegsel (02.30)                  | van den                   |
+    | geslachtsnaam (02.40)                | Aedel                     |
+    | aanduiding naamgebruik (61.10)       | <naamgebruik>             |
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                        | waarde    |
     | burgerservicenummer         | 999992935 |
     | geslachtsaanduiding (04.10) | V         |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde                            |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat partner> |
     | voorvoegsel (02.30)                  | de                                |
@@ -632,7 +632,7 @@ Rule: Voor het bepalen van de aanhef gaat gebruik van de adellijke titel van de 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -654,38 +654,38 @@ Rule: Bij meerdere actuele (niet ontbonden) huwelijken/partnerschappen worden de
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                           | waarde             |
     | voorvoegsel (02.30)            |                    |
     | geslachtsnaam (02.40)          | Groen              |
     | voornamen (02.10)              | Ferdinand Cornelis |
     | aanduiding naamgebruik (61.10) | V                  |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Geel   |
-    En de partner heeft de volgende aangaanHuwelijkPartnerschap gegevens
-    | naam                  | waarde   |
-    | datum aangaan (06.10) | 19580401 |
-    En de persoon heeft een partner met de volgende gegevens
+    En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+    | naam                                                               | waarde   |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19580401 |
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992936 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Roodt  |
-    En de partner heeft de volgende aangaanHuwelijkPartnerschap gegevens
-    | naam                  | waarde   |
-    | datum aangaan (06.10) | 19610808 |
+    En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+    | naam                                                               | waarde   |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19610808 |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde                     |
     | aanhef | Geachte mevrouw Geel-Groen |
 
@@ -696,40 +696,44 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                           | waarde |
     | voorvoegsel (02.30)            |        |
     | geslachtsnaam (02.40)          | Wit    |
     | voornamen (02.10)              | Jan    |
     | aanduiding naamgebruik (61.10) | V      |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Geel   |
-    En de partner heeft de volgende aangaanHuwelijkPartnerschap gegevens
-    | naam                     | waarde   |
-    | datum aangaan (06.10)    | 19580401 |
-    | datum ontbinding (07.10) | 19601001 |
-    En de persoon heeft een partner met de volgende gegevens
+    En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+    | naam                                                               | waarde   |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19580401 |
+    En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+    | naam                                                         | waarde   |
+    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 19601001 |
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992936 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Roodt  |
-    En de partner heeft de volgende aangaanHuwelijkPartnerschap gegevens
-    | naam                     | waarde   |
-    | datum aangaan (06.10)    | 19610422 |
-    | datum ontbinding (07.10) | 20061014 |
+    En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+    | naam                                                               | waarde   |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19610422 |
+    En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+    | naam                                                         | waarde   |
+    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20061014 |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde                    |
     | aanhef | Geachte mevrouw Roodt-Wit |
 
@@ -738,40 +742,44 @@ Rule: Bij meerdere huwelijken/partnerschappen die allen ontbonden zijn, worden d
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                           | waarde |
     | voorvoegsel (02.30)            |        |
     | geslachtsnaam (02.40)          | Wit    |
     | voornamen (02.10)              | Jan    |
     | aanduiding naamgebruik (61.10) | V      |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Zwart  |
-    En de partner heeft de volgende aangaanHuwelijkPartnerschap gegevens
-    | naam                     | waarde   |
-    | datum aangaan (06.10)    | 19580401 |
-    | datum ontbinding (07.10) | 20061001 |
-    En de persoon heeft een partner met de volgende gegevens
+    En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+    | naam                                                               | waarde   |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19580401 |
+    En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+    | naam                                                         | waarde   |
+    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20061001 |
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992936 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                  | waarde |
     | voorvoegsel (02.30)   |        |
     | geslachtsnaam (02.40) | Blaauw |
-    En de partner heeft de volgende aangaanHuwelijkPartnerschap gegevens
-    | naam                     | waarde   |
-    | datum aangaan (06.10)    | 19610422 |
-    | datum ontbinding (07.10) | 19831014 |
+    En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+    | naam                                                               | waarde   |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19610422 |
+    En de 'partner' heeft de volgende 'ontbindingHuwelijkPartnerschap' gegevens
+    | naam                                                         | waarde   |
+    | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 19831014 |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde                    |
     | aanhef | Geachte mevrouw Zwart-Wit |
 
@@ -787,17 +795,17 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde        |
     | voornamen (02.10)                    |               |
     | adellijke titel of predicaat (02.20) |               |
     | voorvoegsel (02.30)                  |               |
     | geslachtsnaam (02.40)                |               |
     | aanduiding naamgebruik (61.10)       | <naamgebruik> |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                        | waarde |
     | geslachtsaanduiding (04.10) | M      |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
@@ -807,7 +815,9 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' <leveren naam> 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
+    | naam   | waarde   |
+    | aanhef | <aanhef> |
 
     Voorbeelden:
       | naamgebruik | aanhef                  | leveren naam |
@@ -821,17 +831,17 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde                    |
     | voornamen (02.10)                    | Jo Anne                   |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat> |
     | voorvoegsel (02.30)                  |                           |
     | geslachtsnaam (02.40)                |                           |
     | aanduiding naamgebruik (61.10)       | <naamgebruik>             |
-    En de persoon heeft een partner met de volgende gegevens
+    En de persoon heeft een 'partner' met de volgende gegevens
     | naam                | waarde    |
     | burgerservicenummer | 999992935 |
-    En de partner heeft de volgende naam gegevens
+    En de 'partner' heeft de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  | de     |
@@ -841,7 +851,9 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' <leveren naam> 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
+    | naam   | waarde   |
+    | aanhef | <aanhef> |
 
     Voorbeelden:
       | geslacht | adellijkeTitelPredicaat | naamgebruik | aanhef                  | leveren naam |
@@ -868,14 +880,14 @@ Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon 
     | naam                        | waarde    |
     | burgerservicenummer         | 999992934 |
     | geslachtsaanduiding (04.10) | V         |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde        |
     | voornamen (02.10)                    |               |
     | adellijke titel of predicaat (02.20) |               |
     | voorvoegsel (02.30)                  | de            |
     | geslachtsnaam (02.40)                | Boer          |
     | aanduiding naamgebruik (61.10)       | <naamgebruik> |
-    En de partner heeft de volgende naam gegevens
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                                 | waarde |
     | adellijke titel of predicaat (02.20) |        |
     | voorvoegsel (02.30)                  |        |
@@ -885,7 +897,7 @@ Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde                  |
     | aanhef | Geachte mevrouw De Boer |
 
@@ -901,14 +913,14 @@ Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon 
     | naam                        | waarde     |
     | burgerservicenummer         | 999992934  |
     | geslachtsaanduiding (04.10) | <geslacht> |
-    En de persoon heeft de volgende naam gegevens
+    En de persoon heeft de volgende 'naam' gegevens
     | naam                                 | waarde        |
     | voornamen (02.10)                    | Jo Anne       |
     | adellijke titel of predicaat (02.20) |               |
     | voorvoegsel (02.30)                  | de            |
     | geslachtsnaam (02.40)                | Boer          |
-    | aanduidingNaamgebruik (61.10)        | <naamgebruik> |
-    En de partner heeft de volgende naam gegevens
+    | aanduiding naamgebruik (61.10)       | <naamgebruik> |
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
     | naam                                 | waarde                            |
     | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat partner> |
     | voorvoegsel (02.30)                  |                                   |
@@ -918,7 +930,7 @@ Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon 
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 999992934                       |
     | fields              | naam.aanhef                     |
-    Dan heeft de persoon met burgerservicenummer '999992934' de volgende 'naam' gegevens
+    Dan heeft de response een persoon met de volgende 'naam' gegevens
     | naam   | waarde   |
     | aanhef | <aanhef> |
 
@@ -928,7 +940,7 @@ Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon 
     | V        | G                               | V           | Hooggeboren vrouwe      |
     | V        | G                               | N           | Hooggeboren vrouwe      |
     | V        | G                               | P           | Hooggeboren vrouwe      |
-    | M        | G                               | V           | Geachte mevrouw De Boer |
-    | O        | G                               | V           | Geachte mevrouw De Boer |
+    | M        | G                               | V           | Geachte heer De Boer    |
+    | O        | G                               | V           | Geachte J.A. de Boer    |
     | V        | GI                              | V           | Geachte mevrouw De Boer |
     | V        | JH                              | V           | Geachte mevrouw De Boer |

--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -210,7 +210,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
   - Wanneer de combinatie van adellijkeTitelPredicaat en geslacht niet voorkomt in bovenstaande tabel: geslacht "O" en geen prins of prinses
   - Wanneer de persoon de geslachtsnaam van de echtgenoot/partner gebruikt zonder de eigen geslachtsnaam: aanduidingNaamgebruik is "P"
   - Wanneer de persoon een predicaat heeft en het geslacht is gelijk aan "V" (vrouw) en betrokkene heeft een actuele partner
-  - Wanneer de persoon een predicaat heeft en het geslacht is gelijk aan "V" (vrouw) en betrokkene gebruikt de naam van de (ex)partner (aanduidingNaamgebruik is ongelijk aan "E")
+  - Wanneer de persoon een predicaat heeft en het geslacht is gelijk aan "V" (vrouw) en betrokkene heeft een ex-partner en gebruikt de naam van de ex-partner (aanduidingNaamgebruik is ongelijk aan "E")
 
   Abstract Scenario: persoon heeft adellijke titel "<adellijkeTitelPredicaat>" en geslacht "<geslacht>"
     Gegeven het systeem heeft een persoon met de volgende gegevens

--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -209,7 +209,7 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
   De aanhef wordt op dezelfde manier samengesteld als voor een persoon zonder adellijke titel of predicaat in de volgende gevallen:
   - Wanneer de combinatie van adellijkeTitelPredicaat en geslacht niet voorkomt in bovenstaande tabel: geslacht "O" en geen prins of prinses
   - Wanneer de persoon de geslachtsnaam van de echtgenoot/partner gebruikt zonder de eigen geslachtsnaam: aanduidingNaamgebruik is "P"
-  - Wanneer de persoon een predicaat heeft en het geslacht is gelijk aan "V" (vrouw) en betrokkene heeft een partner
+  - Wanneer de persoon een predicaat heeft en het geslacht is gelijk aan "V" (vrouw) en betrokkene heeft een actuele partner
   - Wanneer de persoon een predicaat heeft en het geslacht is gelijk aan "V" (vrouw) en betrokkene gebruikt de naam van de (ex)partner (aanduidingNaamgebruik is ongelijk aan "E")
 
   Abstract Scenario: persoon heeft adellijke titel "<adellijkeTitelPredicaat>" en geslacht "<geslacht>"
@@ -331,10 +331,10 @@ Rule: De aanhef voor een persoon met adellijke titel of predicaat wordt bepaald 
     | aanhef | <aanhef> |
 
     Voorbeelden:
-      | geslacht | aanhef                   |
-      | M        | Hoogwelgeboren heer      |
-      | V        | Hoogwelgeboren vrouwe    |
-      | O        | Geachte P. van den Aedel |
+      | geslacht | aanhef                        |
+      | M        | Hoogwelgeboren heer           |
+      | V        | Geachte mevrouw Van den Aedel |
+      | O        | Geachte P. van den Aedel      |
 
   Abstract Scenario: persoon met partner heeft predicaat en naamgebruik "<naamgebruik>"
     Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -588,23 +588,23 @@ Rule: Voor het bepalen van de aanhef gaat gebruik van de adellijke titel van de 
     | aanhef | <aanhef> |
 
     Voorbeelden:
-      | adellijkeTitelPredicaat | adellijkeTitelPredicaat partner | naamgebruik | aanhef                                |
-      | GI                      | B                               | E           | Hooggeboren vrouwe                    |
-      | GI                      | B                               | P           | Hoogwelgeboren vrouwe                 |
-      | GI                      | B                               | V           | Hoogwelgeboren vrouwe                 |
-      | GI                      | B                               | N           | Hoogwelgeboren vrouwe                 |
-      | BS                      | P                               | E           | Hoogwelgeboren vrouwe                 |
-      | BS                      | P                               | P           | Hoogheid                              |
-      | BS                      | P                               | V           | Hoogheid                              |
-      | BS                      | P                               | N           | Hoogheid                              |
-      | GI                      | R                               | E           | Hooggeboren vrouwe                    |
-      | GI                      | R                               | P           | Geachte mevrouw De Boer               |
-      | GI                      | R                               | V           | Geachte mevrouw De Boer-van den Aedel |
-      | GI                      | R                               | N           | Geachte mevrouw Van den Aedel-de Boer |
-      | PS                      | B                               | E           | Hoogheid                              |
-      | PS                      | B                               | P           | Hoogwelgeboren vrouwe                 |
-      | PS                      | B                               | V           | Hoogwelgeboren vrouwe                 |
-      | PS                      | B                               | N           | Hoogwelgeboren vrouwe                 |
+      | adellijkeTitelPredicaat | adellijkeTitelPredicaat partner | naamgebruik | aanhef                  |
+      | GI                      | B                               | E           | Hooggeboren vrouwe      |
+      | GI                      | B                               | P           | Hoogwelgeboren vrouwe   |
+      | GI                      | B                               | V           | Hoogwelgeboren vrouwe   |
+      | GI                      | B                               | N           | Hoogwelgeboren vrouwe   |
+      | BS                      | P                               | E           | Hoogwelgeboren vrouwe   |
+      | BS                      | P                               | P           | Hoogheid                |
+      | BS                      | P                               | V           | Hoogheid                |
+      | BS                      | P                               | N           | Hoogheid                |
+      | GI                      | R                               | E           | Hooggeboren vrouwe      |
+      | GI                      | R                               | P           | Geachte mevrouw De Boer |
+      | GI                      | R                               | V           | Hooggeboren vrouwe      |
+      | GI                      | R                               | N           | Hooggeboren vrouwe      |
+      | PS                      | B                               | E           | Hoogheid                |
+      | PS                      | B                               | P           | Hoogwelgeboren vrouwe   |
+      | PS                      | B                               | V           | Hoogwelgeboren vrouwe   |
+      | PS                      | B                               | N           | Hoogwelgeboren vrouwe   |
 
   Abstract Scenario: man heeft adellijke titel <adellijkeTitelPredicaat> en zijn partner heeft adellijke titel "<adellijkeTitelPredicaat partner>" bij aanduidingNaamgebruik "<naamgebruik>"
     Gegeven het systeem heeft een persoon met de volgende gegevens


### PR DESCRIPTION
- aanpassingen zijn gedaan tbv automation
- specificatie fouten zijn gecorrigeerd
- scenario's toegevoegd tbv bepalen eerste actuele partner en laatste ontbonden partner icm onvolledige datums
  closes #1048

er scenario's die volgens mij niet kloppen volgens de rules maar zeker weet ik het niet

- scenario op regel 304, voorbeeld van regel 336. Deze persoon heeft predicaat = JV en aanduidingnaamgebruik = E en geslacht = V, dan zou  volgens mij de aanhef gelijk moeten zijn aan de aanhef horende bij de predicaat. Volgens mij is dit een voorbeeld van rule 212 en 213, maar weet ik niet zeker. Ook heb ik het gevoel dat deze twee rules die bijna identiek zijn, elkaar tegenspreken. Rule 212 zegt volgens mij dat het niet uitmaakt wat de aanduidingnaamgebruik is, maar rule 213 zegt behalve aanduidingnaamgebruik E
- voor scenario op regel 560 kloppen volgens mij de voorbeelden op regel 602 en 603 niet. De naamgebruik van regel 603 is volgens mij niet correct, want dan zou deze hetzelfde zijn als de voorbeeld van regel 601. Volgens mij zou voor deze twee voorbeelden de rule op regel 209 moeten gelden. De persoon is vrouw, heeft een predicaat, de partner is man en aanduidingnaamgebruik is ongelijk aan E, dus dan zou de aanhef moeten worden samengesteld als een persoon zonder adellijke titel of predicaat
- Hoe moet regel 790 worden geïnterpreteerd? Als ik kijk naar de voorbeeld op regel 866, dan zou ik zeggen dat de persoon of een predicaat heeft of dat de adellijke titel in combinatie met geslacht geen aanspreekvorm heeft. Anders klopt de voorbeeld op regel 866 niet