### PR TITLE
Feature/fields als array

### DIFF
--- a/specificatie/filter.yaml
+++ b/specificatie/filter.yaml
@@ -6,7 +6,7 @@ info:
 paths: {}
 components:
   parameters:
-    Fields:
+    Field:
       name: fields
       in: query
       required: true

--- a/specificatie/filter.yaml
+++ b/specificatie/filter.yaml
@@ -8,7 +8,7 @@ components:
   schemas:
     Field:
       description: |
-          Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
+          Bij opgave van paden die verwijzen naar niet-bestaande velden wordt een 400 Bad Request teruggegeven.
           Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
       type: string
       pattern: ^[a-zA-Z0-9\._]+$

--- a/specificatie/filter.yaml
+++ b/specificatie/filter.yaml
@@ -5,14 +5,6 @@ info:
   contact: {}
 paths: {}
 components:
-  parameters:
-    Field:
-      name: fields
-      in: query
-      required: true
-      schema:
-        $ref: '#/components/schemas/Field'
-
   schemas:
     Field:
       description: |

--- a/specificatie/filter.yaml
+++ b/specificatie/filter.yaml
@@ -16,7 +16,7 @@ components:
   schemas:
     Field:
       description: |
-          Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
+          Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
           Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
       type: string
       pattern: ^[a-zA-Z0-9\._]+$

--- a/specificatie/filter.yaml
+++ b/specificatie/filter.yaml
@@ -16,12 +16,12 @@ components:
   schemas:
     Fields:
       description: |
-          Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven.
+          Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
           Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
           Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
       type: string
-      pattern: ^[a-zA-Z0-9\.,_]+$
-      maxLength: 924
+      pattern: ^[a-zA-Z0-9\._]+$
+      maxLength: 200
     GeslachtFilter:
       description: |
         Geeft aan dat de persoon een man of een vrouw is, of dat het geslacht (nog) onbekend is.

--- a/specificatie/filter.yaml
+++ b/specificatie/filter.yaml
@@ -11,12 +11,11 @@ components:
       in: query
       required: true
       schema:
-        $ref: '#/components/schemas/Fields'
+        $ref: '#/components/schemas/Field'
 
   schemas:
-    Fields:
+    Field:
       description: |
-          Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
           Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
           Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
       type: string

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -766,10 +766,10 @@
         "example" : "546376728"
       },
       "Fields" : {
-        "maxLength" : 924,
-        "pattern" : "^[a-zA-Z0-9\\.,_]+$",
+        "maxLength" : 200,
+        "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven.\nBij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\nBij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -396,7 +396,7 @@
             "maxItems" : 130,
             "minItems" : 1,
             "type" : "array",
-            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\n",
+            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)\n",
             "items" : {
               "$ref" : "#/components/schemas/Field"
             }

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -775,7 +775,7 @@
         "maxLength" : 200,
         "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -393,7 +393,13 @@
             "type" : "string"
           },
           "fields" : {
-            "$ref" : "#/components/schemas/Fields"
+            "maxItems" : 130,
+            "minItems" : 1,
+            "type" : "array",
+            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/Field"
+            }
           },
           "gemeenteVanInschrijving" : {
             "$ref" : "#/components/schemas/GemeenteVanInschrijving"
@@ -765,11 +771,11 @@
         "description" : "Het nummer van het verstrekte Nederlandse reisdocument.\n",
         "example" : "546376728"
       },
-      "Fields" : {
+      "Field" : {
         "maxLength" : 200,
         "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\nBij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -396,7 +396,7 @@
             "maxItems" : 130,
             "minItems" : 1,
             "type" : "array",
-            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)\n",
+            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields.feature)). \nDe te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields-Persoon.csv) (voor gebruik fields bij raadplegen) en [fields-PersoonBeperkt.csv](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/fields-PersoonBeperkt.csv) (voor gebruik fields bij zoeken) waarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.\n",
             "items" : {
               "$ref" : "#/components/schemas/Field"
             }

--- a/specificatie/gba-genereervariant/openapi.json
+++ b/specificatie/gba-genereervariant/openapi.json
@@ -775,7 +775,7 @@
         "maxLength" : 200,
         "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Bij opgave van paden die verwijzen naar niet-bestaande velden wordt een 400 Bad Request teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -605,7 +605,7 @@ components:
       pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
+        Bij opgave van paden die verwijzen naar niet-bestaande velden wordt een 400 Bad Request teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:
       pattern: ^[0-9]{4}$

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -321,7 +321,13 @@ components:
         type:
           type: string
         fields:
-          $ref: '#/components/schemas/Fields'
+          maxItems: 130
+          minItems: 1
+          type: array
+          description: |
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
+          items:
+            $ref: '#/components/schemas/Field'
         gemeenteVanInschrijving:
           $ref: '#/components/schemas/GemeenteVanInschrijving'
       discriminator:
@@ -594,12 +600,11 @@ components:
       description: |
         Het nummer van het verstrekte Nederlandse reisdocument.
       example: "546376728"
-    Fields:
+    Field:
       maxLength: 200
       pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
         Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -595,11 +595,11 @@ components:
         Het nummer van het verstrekte Nederlandse reisdocument.
       example: "546376728"
     Fields:
-      maxLength: 924
-      pattern: ^[a-zA-Z0-9\.,_]+$
+      maxLength: 200
+      pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven.
+        Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
         Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -325,7 +325,7 @@ components:
           minItems: 1
           type: array
           description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)
           items:
             $ref: '#/components/schemas/Field'
         gemeenteVanInschrijving:

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -605,7 +605,7 @@ components:
       pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
+        Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:
       pattern: ^[0-9]{4}$

--- a/specificatie/gba-genereervariant/openapi.yaml
+++ b/specificatie/gba-genereervariant/openapi.yaml
@@ -324,8 +324,13 @@ components:
           maxItems: 130
           minItems: 1
           type: array
-          description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen\
+            \ door een lijst van paden die verwijzen naar de gewenste velden op te\
+            \ nemen ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields.feature)).\
+            \ \nDe te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields-Persoon.csv)\
+            \ (voor gebruik fields bij raadplegen) en [fields-PersoonBeperkt.csv](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/fields-PersoonBeperkt.csv)\
+            \ (voor gebruik fields bij zoeken) waarbij in de eerste kolom het fields-pad\
+            \ staat en in de tweede kolom het volledige pad naar het gewenste veld.\n"
           items:
             $ref: '#/components/schemas/Field'
         gemeenteVanInschrijving:

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -396,7 +396,7 @@
             "maxItems" : 130,
             "minItems" : 1,
             "type" : "array",
-            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\n",
+            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)\n",
             "items" : {
               "$ref" : "#/components/schemas/Field"
             }

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -815,7 +815,7 @@
         "maxLength" : 200,
         "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Bij opgave van paden die verwijzen naar niet-bestaande velden wordt een 400 Bad Request teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -815,7 +815,7 @@
         "maxLength" : 200,
         "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -393,7 +393,13 @@
             "type" : "string"
           },
           "fields" : {
-            "$ref" : "#/components/schemas/Fields"
+            "maxItems" : 130,
+            "minItems" : 1,
+            "type" : "array",
+            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\n",
+            "items" : {
+              "$ref" : "#/components/schemas/Field"
+            }
           },
           "gemeenteVanInschrijving" : {
             "$ref" : "#/components/schemas/GemeenteVanInschrijving"
@@ -805,11 +811,11 @@
         "description" : "Het nummer van het verstrekte Nederlandse reisdocument.\n",
         "example" : "546376728"
       },
-      "Fields" : {
+      "Field" : {
         "maxLength" : 200,
         "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\nBij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -806,10 +806,10 @@
         "example" : "546376728"
       },
       "Fields" : {
-        "maxLength" : 924,
-        "pattern" : "^[a-zA-Z0-9\\.,_]+$",
+        "maxLength" : 200,
+        "pattern" : "^[a-zA-Z0-9\\._]+$",
         "type" : "string",
-        "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven.\nBij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
+        "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.\nBij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.\nZie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)\n"
       },
       "GemeenteVanInschrijving" : {
         "pattern" : "^[0-9]{4}$",

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -396,7 +396,7 @@
             "maxItems" : 130,
             "minItems" : 1,
             "type" : "array",
-            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)\n",
+            "description" : "Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields.feature)). \nDe te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields-Persoon.csv) (voor gebruik fields bij raadplegen) en [fields-PersoonBeperkt.csv](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/fields-PersoonBeperkt.csv) (voor gebruik fields bij zoeken) waarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.\n",
             "items" : {
               "$ref" : "#/components/schemas/Field"
             }

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -637,7 +637,7 @@ components:
       pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
+        Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:
       pattern: ^[0-9]{4}$

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -627,11 +627,11 @@ components:
         Het nummer van het verstrekte Nederlandse reisdocument.
       example: "546376728"
     Fields:
-      maxLength: 924
-      pattern: ^[a-zA-Z0-9\.,_]+$
+      maxLength: 200
+      pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen op te geven.
+        Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
         Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -325,8 +325,13 @@ components:
           maxItems: 130
           minItems: 1
           type: array
-          description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)
+          description: "Hiermee kun je de inhoud van de resource naar behoefte aanpassen\
+            \ door een lijst van paden die verwijzen naar de gewenste velden op te\
+            \ nemen ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields.feature)).\
+            \ \nDe te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields-Persoon.csv)\
+            \ (voor gebruik fields bij raadplegen) en [fields-PersoonBeperkt.csv](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/fields-PersoonBeperkt.csv)\
+            \ (voor gebruik fields bij zoeken) waarbij in de eerste kolom het fields-pad\
+            \ staat en in de tweede kolom het volledige pad naar het gewenste veld.\n"
           items:
             $ref: '#/components/schemas/Field'
         gemeenteVanInschrijving:

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -326,7 +326,7 @@ components:
           minItems: 1
           type: array
           description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)
           items:
             $ref: '#/components/schemas/Field'
         gemeenteVanInschrijving:

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -637,7 +637,7 @@ components:
       pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven.
+        Bij opgave van paden die verwijzen naar niet-bestaande velden wordt een 400 Bad Request teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:
       pattern: ^[0-9]{4}$

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -322,7 +322,13 @@ components:
         type:
           type: string
         fields:
-          $ref: '#/components/schemas/Fields'
+          maxItems: 130
+          minItems: 1
+          type: array
+          description: |
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
+          items:
+            $ref: '#/components/schemas/Field'
         gemeenteVanInschrijving:
           $ref: '#/components/schemas/GemeenteVanInschrijving'
       discriminator:
@@ -626,12 +632,11 @@ components:
       description: |
         Het nummer van het verstrekte Nederlandse reisdocument.
       example: "546376728"
-    Fields:
+    Field:
       maxLength: 200
       pattern: ^[a-zA-Z0-9\._]+$
       type: string
       description: |
-        Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
         Bij opgave van niet-bestaande properties wordt een 400 Bad Request teruggegeven. Wanneer de fields parameter niet is opgegeven, worden alle properties met een waarde teruggegeven.
         Zie [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-common/blob/v1.2.0/features/fields.feature)
     GemeenteVanInschrijving:

--- a/specificatie/zoek-personen.yaml
+++ b/specificatie/zoek-personen.yaml
@@ -117,7 +117,7 @@ components:
           type: string
         fields:
           description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)
           type: array
           maxItems: 130
           minItems: 1

--- a/specificatie/zoek-personen.yaml
+++ b/specificatie/zoek-personen.yaml
@@ -117,7 +117,8 @@ components:
           type: string
         fields:
           description: |
-            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven. [zie functionele specificaties fields-parameter](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.3.0/features/fields_extensie.feature)
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een lijst van paden die verwijzen naar de gewenste velden op te nemen ([zie functionele specificaties 'fields' properties](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields.feature)). 
+            De te gebruiken paden zijn beschreven in [fields-Persoon.csv](https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/develop/features/fields-Persoon.csv) (voor gebruik fields bij raadplegen) en [fields-PersoonBeperkt.csv](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/develop/features/fields-PersoonBeperkt.csv) (voor gebruik fields bij zoeken) waarbij in de eerste kolom het fields-pad staat en in de tweede kolom het volledige pad naar het gewenste veld.
           type: array
           maxItems: 130
           minItems: 1

--- a/specificatie/zoek-personen.yaml
+++ b/specificatie/zoek-personen.yaml
@@ -116,7 +116,13 @@ components:
         type:
           type: string
         fields:
-          $ref: 'filter.yaml#/components/schemas/Fields'
+          description: |
+            Hiermee kun je de inhoud van de resource naar behoefte aanpassen door een door komma's gescheiden lijst van property namen of - paden op te geven.
+          type: array
+          maxItems: 130
+          minItems: 1
+          items:
+            $ref: 'filter.yaml#/components/schemas/Field'
         gemeenteVanInschrijving:
           $ref: 'verblijfplaats.yaml#/components/schemas/GemeenteVanInschrijving'
     RaadpleegMetBurgerservicenummer:


### PR DESCRIPTION
Fixes https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/issues/1002

N.a.v. issue https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/issues/1002 is de fields parameter voortaan een array van waarden.

Vervangt PR #1035. Alle daarin gemaakte opmerkingen zijn hierin opgelost.

Daarnaast is ook het component filter.yaml#/components/parameters/Fields verwijderd aangezien dit niet meer gebruikt wordt.