### PR TITLE
wijzigen bijzonderNederlanderschap in string met pattern

### DIFF
--- a/specificatie/nationaliteit.yaml
+++ b/specificatie/nationaliteit.yaml
@@ -80,7 +80,8 @@ components:
       type: object
       properties:
         aanduidingBijzonderNederlanderschap:
-          $ref: 'common.yaml#/components/schemas/Waardetabel'
+          type: string
+          pattern: ^(B|V)$
         datumIngangGeldigheid:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
         nationaliteit:


### PR DESCRIPTION
aangezien aanduidingBijzonderNederlanderschap alleen geleverd wordt in GbaPersoon en door de proxy alleen de code gebruikt wordt, hoeft dit geen Waardetabel te zijn. De omschrijving bij de code is niet relevant.

Daarom dit veld gewijzigd in string met pattern. 