### PR TITLE
fix: OntbindingHuwelijkPartnerschapBasis hernoemd en indicatieHuwelijkPartnerschapBeeindigd veld verwijderd

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -2284,7 +2284,7 @@
             "$ref" : "#/components/schemas/AangaanHuwelijkPartnerschap"
           },
           "ontbindingHuwelijkPartnerschap" : {
-            "$ref" : "#/components/schemas/OntbindingHuwelijkPartnerschapBasis"
+            "$ref" : "#/components/schemas/OntbindingHuwelijkPartnerschap"
           }
         }
       },
@@ -2344,12 +2344,9 @@
           }
         } ]
       },
-      "OntbindingHuwelijkPartnerschapBasis" : {
+      "OntbindingHuwelijkPartnerschap" : {
         "type" : "object",
         "properties" : {
-          "indicatieHuwelijkPartnerschapBeeindigd" : {
-            "type" : "boolean"
-          },
           "datum" : {
             "$ref" : "#/components/schemas/AbstractDatum"
           },

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -2351,12 +2351,12 @@
             "$ref" : "#/components/schemas/AbstractDatum"
           },
           "inOnderzoek" : {
-            "$ref" : "#/components/schemas/OntbindingHuwelijkPartnerschapBasisInOnderzoek"
+            "$ref" : "#/components/schemas/OntbindingHuwelijkPartnerschapInOnderzoek"
           }
         },
         "description" : "Gegevens over de ontbinding van het huwelijk of het geregistreerd partnerschap.\n* **datum** : De datum waarop het huwelijk of het partnerschap is ontbonden.\n"
       },
-      "OntbindingHuwelijkPartnerschapBasisInOnderzoek" : {
+      "OntbindingHuwelijkPartnerschapInOnderzoek" : {
         "description" : "Geeft aan welke gegevens over het onbinden van het huwelijk of aangaan van het partnerschap in onderzoek zijn.\nZie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)\n",
         "allOf" : [ {
           "$ref" : "#/components/schemas/InOnderzoek"

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -1801,11 +1801,11 @@ components:
         datum:
           $ref: '#/components/schemas/AbstractDatum'
         inOnderzoek:
-          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschapBasisInOnderzoek'
+          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschapInOnderzoek'
       description: |
         Gegevens over de ontbinding van het huwelijk of het geregistreerd partnerschap.
         * **datum** : De datum waarop het huwelijk of het partnerschap is ontbonden.
-    OntbindingHuwelijkPartnerschapBasisInOnderzoek:
+    OntbindingHuwelijkPartnerschapInOnderzoek:
       description: |
         Geeft aan welke gegevens over het onbinden van het huwelijk of aangaan van het partnerschap in onderzoek zijn.
         Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -1750,7 +1750,7 @@ components:
         aangaanHuwelijkPartnerschap:
           $ref: '#/components/schemas/AangaanHuwelijkPartnerschap'
         ontbindingHuwelijkPartnerschap:
-          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschapBasis'
+          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschap'
     PartnerInOnderzoek:
       description: |
         Geeft aan welke gegevens over het huwelijk of het partnerschap in onderzoek zijn.
@@ -1795,11 +1795,9 @@ components:
             type: boolean
           plaats:
             type: boolean
-    OntbindingHuwelijkPartnerschapBasis:
+    OntbindingHuwelijkPartnerschap:
       type: object
       properties:
-        indicatieHuwelijkPartnerschapBeeindigd:
-          type: boolean
         datum:
           $ref: '#/components/schemas/AbstractDatum'
         inOnderzoek:

--- a/specificatie/partner.yaml
+++ b/specificatie/partner.yaml
@@ -43,7 +43,7 @@ components:
         aangaanHuwelijkPartnerschap:
           $ref: '#/components/schemas/AangaanHuwelijkPartnerschap'
         ontbindingHuwelijkPartnerschap:
-          $ref: "#/components/schemas/OntbindingHuwelijkPartnerschapBasis"
+          $ref: "#/components/schemas/OntbindingHuwelijkPartnerschap"
     PartnerInOnderzoek:
       description: |
         Geeft aan welke gegevens over het huwelijk of het partnerschap in onderzoek zijn.
@@ -107,14 +107,12 @@ components:
       properties:
         datum:
           $ref: 'datum.yaml#/components/schemas/GbaDatum'
-    OntbindingHuwelijkPartnerschapBasis:
+    OntbindingHuwelijkPartnerschap:
       type: object
       description: |
         Gegevens over de ontbinding van het huwelijk of het geregistreerd partnerschap.
         * **datum** : De datum waarop het huwelijk of het partnerschap is ontbonden.
       properties:
-        indicatieHuwelijkPartnerschapBeeindigd:
-          type: boolean
         datum:
           $ref: 'datum.yaml#/components/schemas/AbstractDatum'
         inOnderzoek:

--- a/specificatie/partner.yaml
+++ b/specificatie/partner.yaml
@@ -116,8 +116,8 @@ components:
         datum:
           $ref: 'datum.yaml#/components/schemas/AbstractDatum'
         inOnderzoek:
-          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschapBasisInOnderzoek'
-    OntbindingHuwelijkPartnerschapBasisInOnderzoek:
+          $ref: '#/components/schemas/OntbindingHuwelijkPartnerschapInOnderzoek'
+    OntbindingHuwelijkPartnerschapInOnderzoek:
       description: |
         Geeft aan welke gegevens over het onbinden van het huwelijk of aangaan van het partnerschap in onderzoek zijn.
         Zie de [functionele specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRP-bevragen/blob/v1.1.0/features/in_onderzoek.feature)


### PR DESCRIPTION
Een partner met ontbindingHuwelijkPartnerschap veld geeft al aan dat de huwelijk/partnerschap met de betreffende partner is beëindigd. Of de indicatieHuwelijkPartnerschapBeeindigd veld moet naar de Partner schema component worden verplaatst zodat een consumer kan zien dat de betreffende partner is ontbonden zonder de ontbindingHuwelijkPartnerschap veld te vragen.