### PR TITLE
fix(specs): correctie op adressering scenario's

### DIFF
--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -699,10 +699,40 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
 
     Voorbeelden:
       | naamgebruik | aanhef                  | leveren naam |
-      | E           |                         | GEEN         |
       | P           | Geachte mevrouw De Boer | WEL          |
-      | V           |                         | GEEN         |
-      | N           |                         | GEEN         |
+
+  Abstract Scenario: naam van de persoon is onbekend bij aanduiding naamgebruik "<naamgebruik>"
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                        | waarde    |
+    | burgerservicenummer         | 999992934 |
+    | geslachtsaanduiding (04.10) | V         |
+    En de persoon heeft de volgende 'naam' gegevens
+    | naam                                 | waarde        |
+    | voornamen (02.10)                    |               |
+    | adellijke titel of predicaat (02.20) |               |
+    | voorvoegsel (02.30)                  |               |
+    | geslachtsnaam (02.40)                |               |
+    | aanduiding naamgebruik (61.10)       | <naamgebruik> |
+    En de persoon heeft een 'partner' met de volgende gegevens
+    | naam                        | waarde |
+    | geslachtsaanduiding (04.10) | M      |
+    En de 'partner' heeft de volgende 'naam' gegevens
+    | naam                                 | waarde |
+    | adellijke titel of predicaat (02.20) |        |
+    | voorvoegsel (02.30)                  | de     |
+    | geslachtsnaam (02.40)                | Boer   |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 999992934                       |
+    | fields              | adressering.aanhef              |
+    Dan heeft de response een persoon met een leeg 'adressering' object
+
+    Voorbeelden:
+      | naamgebruik |
+      | E           |
+      | V           |
+      | N           |
 
   Abstract Scenario: persoon met onbekende naam heeft adellijkeTitelPredicaat "<adellijkeTitelPredicaat>" en geslacht "<geslacht>" en naamgebruik "<naamgebruik>"
     Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -737,11 +767,38 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
       | M        | G                       | N           | Hooggeboren heer        | WEL          |
       | M        | G                       | P           | Geachte heer De Boer    | WEL          |
       | V        | G                       | E           | Hooggeboren vrouwe      | WEL          |
-      | O        | G                       | E           |                         | GEEN         |
-      | V        | JV                      | E           |                         | GEEN         |
-      | V        | JV                      | V           |                         | GEEN         |
-      | V        | JV                      | N           |                         | GEEN         |
       | V        | JV                      | P           | Geachte mevrouw De Boer | WEL          |
+
+  Abstract Scenario: persoon met onbekende naam heeft adellijkeTitelPredicaat "<adellijkeTitelPredicaat>" en geslacht "<geslacht>" en naamgebruik "<naamgebruik>"
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                        | waarde     |
+    | burgerservicenummer         | 999992934  |
+    | geslachtsaanduiding (04.10) | <geslacht> |
+    En de persoon heeft de volgende 'naam' gegevens
+    | naam                                 | waarde                    |
+    | voornamen (02.10)                    | Jo Anne                   |
+    | adellijke titel of predicaat (02.20) | <adellijkeTitelPredicaat> |
+    | voorvoegsel (02.30)                  |                           |
+    | geslachtsnaam (02.40)                |                           |
+    | aanduiding naamgebruik (61.10)       | <naamgebruik>             |
+    En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+    | naam                                 | waarde |
+    | adellijke titel of predicaat (02.20) |        |
+    | voorvoegsel (02.30)                  | de     |
+    | geslachtsnaam (02.40)                | Boer   |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 999992934                       |
+    | fields              | adressering.aanhef              |
+    Dan heeft de response een persoon met een leeg 'adressering' object
+
+    Voorbeelden:
+      | geslacht | adellijkeTitelPredicaat | naamgebruik |
+      | O        | G                       | E           |
+      | V        | JV                      | E           |
+      | V        | JV                      | V           |
+      | V        | JV                      | N           |
 
 Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon wanneer de geslachtsnaam van de partner leeg of onbekend is en de naam van de partner wordt gebruikt
   De aanhef wordt samengesteld voor aanduiding naamgebruik "E" wanneer aan alle volgende condities is voldaan:

--- a/features/adres.feature
+++ b/features/adres.feature
@@ -184,8 +184,8 @@ Functionaliteit: Adresvelden vullen
       | type                | RaadpleegMetBurgerservicenummer                                                          |
       | burgerservicenummer | 555550011                                                                                |
       | fields              | adressering.adresregel1,adressering.adresregel2,adressering.adresregel3,adressering.land |
-      Dan heeft de response een leeg persoon object
-      # personen: [{}]
+      Dan heeft de response een persoon met een leeg 'adressering' object
+      # personen: [{ adressering: {} }]
 
     Scenario: alleen land is bekend
       Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -202,8 +202,8 @@ Functionaliteit: Adresvelden vullen
       | type                | RaadpleegMetBurgerservicenummer                                                          |
       | burgerservicenummer | 555550012                                                                                |
       | fields              | adressering.adresregel1,adressering.adresregel2,adressering.adresregel3,adressering.land |
-      Dan heeft de response een leeg persoon object
-      # personen: [{}]
+      Dan heeft de response een persoon met een leeg 'adressering' object
+      # personen: [{ adressering: {} }]
 
   Rule: Voor een binnenlands adres worden de adresregels in de adressering alleen opgenomen wanneer ten minste straat en huisnummer een waarde hebben
     - een standaardwaarde in de bron geldt hier niet als waarde
@@ -223,8 +223,8 @@ Functionaliteit: Adresvelden vullen
       | type                | RaadpleegMetBurgerservicenummer                                                          |
       | burgerservicenummer | <burgerservicenummer>                                                                    |
       | fields              | adressering.adresregel1,adressering.adresregel2,adressering.adresregel3,adressering.land |
-      Dan heeft de response een leeg persoon object
-      # personen: [{}]
+      Dan heeft de response een persoon met een leeg 'adressering' object
+      # personen: [{ adressering: {} }]
 
       Voorbeelden:
       | omschrijving                     | burgerservicenummer | straatnaam               | huisnummer | postcode |

--- a/features/dev/persoon-adressering-inonderzoek.feature
+++ b/features/dev/persoon-adressering-inonderzoek.feature
@@ -465,7 +465,6 @@ Functionaliteit: Persoon adressering in onderzoek
 
       Voorbeelden:
       | gba in onderzoek waarde |
-      | 080910                  |
       | 080920                  |
       | 081000                  |
       | 081010                  |

--- a/features/gebruik_in_lopende_tekst.feature
+++ b/features/gebruik_in_lopende_tekst.feature
@@ -589,19 +589,49 @@ Rule: Wanneer de geslachtsnaam van de persoon leeg of onbekend is en de naam van
     | gebruikInLopendeTekst | <gebruik in lopende tekst> |
 
     Voorbeelden:
-    | geslachtsnaam | naamgebruik | leveren naam | gebruik in lopende tekst |
-    | .             | E           | GEEN         |                          |
-    | .             | P           | WEL          | mevrouw De Boer          |
-    | .             | V           | GEEN         |                          |
-    | .             | N           | GEEN         |                          |
-    |               | E           | GEEN         |                          |
-    |               | P           | WEL          | mevrouw De Boer          |
-    |               | V           | GEEN         |                          |
-    |               | N           | GEEN         |                          |
-    | Jansen        | E           | WEL          | mevrouw Jansen           |
-    | Jansen        | P           | WEL          | mevrouw De Boer          |
-    | Jansen        | V           | WEL          | mevrouw De Boer-Jansen   |
-    | Jansen        | N           | WEL          | mevrouw Jansen-de Boer   |
+    | geslachtsnaam | naamgebruik | gebruik in lopende tekst |
+    | .             | P           | mevrouw De Boer          |
+    |               | P           | mevrouw De Boer          |
+    | Jansen        | E           | mevrouw Jansen           |
+    | Jansen        | P           | mevrouw De Boer          |
+    | Jansen        | V           | mevrouw De Boer-Jansen   |
+    | Jansen        | N           | mevrouw Jansen-de Boer   |
+
+    Abstract Scenario: naam van de persoon is onbekend bij aanduiding naamgebruik "<naamgebruik>"
+    Gegeven het systeem heeft een persoon met de volgende gegevens
+    | naam                        | waarde    |
+    | burgerservicenummer         | 999992934 |
+    | geslachtsaanduiding (04.10) | V         |
+    En de persoon heeft de volgende 'naam' gegevens
+    | naam                                 | waarde          |
+    | voornamen (02.10)                    |                 |
+    | adellijke titel of predicaat (02.20) |                 |
+    | voorvoegsel (02.30)                  |                 |
+    | geslachtsnaam (02.40)                | <geslachtsnaam> |
+    | aanduiding naamgebruik (61.10)       | <naamgebruik>   |
+    En de persoon heeft een 'partner' met de volgende gegevens
+    | naam                        | waarde |
+    | geslachtsaanduiding (04.10) | M      |
+    En de 'partner' heeft de volgende 'naam' gegevens
+    | naam                                 | waarde |
+    | adellijke titel of predicaat (02.20) |        |
+    | voorvoegsel (02.30)                  | de     |
+    | geslachtsnaam (02.40)                | Boer   |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                            |
+    | type                | RaadpleegMetBurgerservicenummer   |
+    | burgerservicenummer | 999992934                         |
+    | fields              | adressering.gebruikInLopendeTekst |
+    Dan heeft de response een persoon met een leeg 'adressering' object
+
+    Voorbeelden:
+    | geslachtsnaam | naamgebruik |
+    | .             | E           |
+    | .             | V           |
+    | .             | N           |
+    |               | E           |
+    |               | V           |
+    |               | N           |
 
 Rule: Aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd voor een persoon wanneer de geslachtsnaam van de partner leeg of onbekend is en de naam van de partner wordt gebruikt
   - de geslachtsnaam van de partner is leeg of onbekend (.)


### PR DESCRIPTION
Het adressering object moet (volgens mij) leeg zijn als een persoon een naam of verblijfplaats heeft