### PR TITLE
Feature: aanschrijfwijze

### DIFF
--- a/features/aanschrijfwijze-persoon-met-partner-zonder-adellijke-titel-predicaat.feature
+++ b/features/aanschrijfwijze-persoon-met-partner-zonder-adellijke-titel-predicaat.feature
@@ -1,0 +1,341 @@
+#language: nl
+
+Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke titel/predicaat
+
+  Rule: Voor een persoon zonder adellijke titel of predicaat, met een (ex-)partner zonder adellijke titel of predicaat,
+        wordt de naam in aanschrijfwijze als volgt samengesteld:
+        | aanduiding naamgebruik | omschrijving                 | naam in aanschrijfwijze |
+        | E                      | eigen naam                   | VL VV GN                |
+        | P                      | partner naam                 | VL VP GP                |
+        | V                      | partner naam voor eigen naam | VL VP GP-VV GN          |
+        | N                      | partner naam na eigen naam   | VL VV GN-VP GP          |
+
+    Abstract Scenario: persoon zonder voorvoegsel heeft (ex-)partner zonder voorvoegsel, en heeft aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | geslachtsnaam (02.40)          | Groenen       |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En die persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Aedel  |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde                    |
+      | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
+
+      Voorbeelden:
+      | naamgebruik | naam in aanschrijfwijze |
+      | E           | F. Groenen              |
+      | P           | F. Aedel                |
+      | V           | F. Aedel-Groenen        |
+      | N           | F. Groenen-Aedel        |
+
+    Abstract Scenario: persoon met voorvoegsel heeft (ex-)partner zonder voorvoegsel, en heeft aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | voorvoegsel (02.30)            | <voorvoegsel> |
+      | geslachtsnaam (02.40)          | Groenen       |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En die persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Aedel  |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                 | waarde                    |
+      | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
+
+      Voorbeelden:
+      | naamgebruik | voorvoegsel | naam in aanschrijfwijze |
+      | E           | van         | F. van Groenen          |
+      | P           | Van         | F. Aedel                |
+      | V           | in het      | F. Aedel-in het Groenen |
+      | N           | In Den      | F. In Den Groenen-Aedel |
+
+    Abstract Scenario: persoon zonder voorvoegsel, met (ex-)partner met voorvoegsel, heeft aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | geslachtsnaam (02.40)          | Groenen       |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En die persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde                |
+      | voorvoegsel (02.30)   | <voorvoegsel partner> |
+      | geslachtsnaam (02.40) | Aedel                 |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                 | waarde                    |
+      | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
+
+      Voorbeelden:
+      | naamgebruik | voorvoegsel partner | naam in aanschrijfwijze |
+      | E           | van                 | F. Groenen              |
+      | P           | Van                 | F. Van Aedel            |
+      | V           | in het              | F. in het Aedel-Groenen |
+      | N           | In Den              | F. Groenen-In Den Aedel |
+
+    Abstract Scenario: persoon met voorvoegsel, met (ex-)partner met voorvoegsel, heeft aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft alleen de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | voorvoegsel (02.30)            | <voorvoegsel> |
+      | geslachtsnaam (02.40)          | Groenen       |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En die persoon heeft een 'partner' met de volgende relevante 'naam' gegevens
+      | naam                  | waarde                |
+      | voorvoegsel (02.30)   | <voorvoegsel partner> |
+      | geslachtsnaam (02.40) | Aedel                 |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde                    |
+      | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
+
+      Voorbeelden:
+      | naamgebruik | voorvoegsel | voorvoegsel partner | naam in aanschrijfwijze          |
+      | E           | in het      | Van                 | F. in het Groenen                |
+      | P           | Van         | van den             | F. van den Aedel                 |
+      | V           | In Het      | van                 | F. van Aedel-In Het Groenen      |
+      | N           | van den     | Van Den             | F. van den Groenen-Van Den Aedel |
+
+    Abstract Scenario: persoon met (ex-)partner, heeft een naamketen en aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft de alleen volgende 'naam' gegevens
+      | naam                           | waarde          |
+      | geslachtsnaam (02.40)          | <geslachtsnaam> |
+      | aanduiding naamgebruik (61.10) | <naamgebruik>   |
+      En die persoon heeft een 'partner' met de volgende relevante 'naam' gegevens
+      | naam                  | waarde |
+      | voorvoegsel (02.30)   | van    |
+      | geslachtsnaam (02.40) | Velzen |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde                    |
+      | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
+
+      Voorbeelden:
+      | geslachtsnaam     | naamgebruik | naam in aanschrijfwijze      |
+      | Ali bin Mohammed  | E           | Ali bin Mohammed             |
+      | Ali bin Mohammed  | P           | Van Velzen                   |
+      | Ibin binti Yalniz | V           | Van Velzen-Ibin binti Yalniz |
+      | Ibin binti Yalniz | N           | Ibin binti Yalniz-van Velzen |
+
+  Rule: er is geen aanschrijfwijze als de geslachtsnaam van de persoon gelijk is aan de standaardwaarde en aanduiding naamgebruik is ongelijk aan "P"
+
+    Abstract Scenario: persoon met (ex-)partner, heeft een geslachtsnaam met standaardwaarde, en heeft aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | geslachtsnaam (02.40)          | .             |
+      | voornamen (02.10)              | Franklin      |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Aedel  |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze.naam            |
+      Dan heeft de response een persoon met een leeg 'adressering' object
+
+      Voorbeelden:
+      | naamgebruik |
+      | E           |
+      | V           |
+      | N           |
+
+    Abstract Scenario: persoon met (ex-)partner, heeft geen geslachtsnaam, en heeft aanduiding naamgebruik "<naamgebruik>"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Aedel  |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze.naam            |
+      Dan heeft de response een persoon met een leeg 'adressering' object
+
+      Voorbeelden:
+      | naamgebruik |
+      | E           |
+      | V           |
+      | N           |
+
+    Scenario: persoon met (ex-)partner, heeft een geslachtsnaam met standaardwaarde, en heeft aanduiding naamgebruik "P"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde   |
+      | geslachtsnaam (02.40)          | .        |
+      | voornamen (02.10)              | Franklin |
+      | aanduiding naamgebruik (61.10) | P        |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Aedel  |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze.naam            |
+      Dan heeft de response een persoon met de volgende 'adressering' naam
+      | naam                 | waarde   |
+      | aanschrijfwijze.naam | F. Aedel |
+
+    Scenario: persoon met (ex-)partner, heeft geen geslachtsnaam met standaardwaarde, en heeft aanduiding naamgebruik "P"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde   |
+      | voornamen (02.10)              | Franklin |
+      | aanduiding naamgebruik (61.10) | P        |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Aedel  |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze.naam            |
+      Dan heeft de response een persoon met de volgende 'adressering' naam
+      | naam                 | waarde   |
+      | aanschrijfwijze.naam | F. Aedel |
+
+  Rule: er is geen aanschrijfwijze als de geslachtsnaam van de partner gelijk is aan de standaardwaard en aanduiding naamgebruik is ongelijk aan "E"
+
+    Abstract Scenario: persoon met aanduiding naamgebruik "<naamgebruik>", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | geslachtsnaam (02.40)          | Groenen       |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | .      |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met een leeg 'adressering' object
+
+      Voorbeelden:
+      | naamgebruik |
+      | P           |
+      | V           |
+      | N           |
+
+    Scenario: persoon met aanduiding naamgebruik "E", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde   |
+      | voornamen (02.10)              | Franklin |
+      | geslachtsnaam (02.40)          | Groenen  |
+      | aanduiding naamgebruik (61.10) | E        |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | .      |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                 | waarde     |
+      | aanschrijfwijze.naam | F. Groenen |
+
+    Abstract Scenario: persoon met aanduiding naamgebruik "<naamgebruik>", heeft een partner zonder geslachtsnaam
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde        |
+      | voornamen (02.10)              | Franklin      |
+      | geslachtsnaam (02.40)          | Groenen       |
+      | aanduiding naamgebruik (61.10) | <naamgebruik> |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam              | waarde  |
+      | voornamen (02.10) | Jantine |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met een leeg 'adressering' object
+
+      Voorbeelden:
+      | naamgebruik |
+      | P           |
+      | V           |
+      | N           |
+
+    Scenario: persoon met aanduiding naamgebruik "E", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                           | waarde   |
+      | voornamen (02.10)              | Franklin |
+      | geslachtsnaam (02.40)          | Groenen  |
+      | aanduiding naamgebruik (61.10) | E        |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam              | waarde  |
+      | voornamen (02.10) | Jantine |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                 | waarde     |
+      | aanschrijfwijze.naam | F. Groenen |

--- a/features/aanschrijfwijze-persoon-met-partner-zonder-adellijke-titel-predicaat.feature
+++ b/features/aanschrijfwijze-persoon-met-partner-zonder-adellijke-titel-predicaat.feature
@@ -9,6 +9,7 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
         | P                      | partner naam                 | VL VP GP                |
         | V                      | partner naam voor eigen naam | VL VP GP-VV GN          |
         | N                      | partner naam na eigen naam   | VL VV GN-VP GP          |
+        - voorvoegsel wordt gebruikt zoals het is geregistreerd
 
     Abstract Scenario: persoon zonder voorvoegsel heeft (ex-)partner zonder voorvoegsel, en heeft aanduiding naamgebruik "<naamgebruik>"
       Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -226,7 +227,7 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | naam                 | waarde   |
       | aanschrijfwijze.naam | F. Aedel |
 
-    Scenario: persoon met (ex-)partner, heeft geen geslachtsnaam met standaardwaarde, en heeft aanduiding naamgebruik "P"
+    Scenario: persoon met (ex-)partner, heeft geen geslachtsnaam, en heeft aanduiding naamgebruik "P"
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 999992934 |
@@ -246,7 +247,7 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | naam                 | waarde   |
       | aanschrijfwijze.naam | F. Aedel |
 
-  Rule: er is geen aanschrijfwijze als de geslachtsnaam van de partner gelijk is aan de standaardwaard en aanduiding naamgebruik is ongelijk aan "E"
+  Rule: er is geen aanschrijfwijze als de geslachtsnaam van de partner gelijk is aan de standaardwaarde en aanduiding naamgebruik is ongelijk aan "E"
 
     Abstract Scenario: persoon met aanduiding naamgebruik "<naamgebruik>", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
       Gegeven het systeem heeft een persoon met de volgende gegevens

--- a/features/aanschrijfwijze-persoon-met-partner-zonder-adellijke-titel-predicaat.feature
+++ b/features/aanschrijfwijze-persoon-met-partner-zonder-adellijke-titel-predicaat.feature
@@ -15,12 +15,12 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 999992934 |
-      En die persoon heeft de volgende 'naam' gegevens
+      En de persoon heeft de volgende 'naam' gegevens
       | naam                           | waarde        |
       | voornamen (02.10)              | Franklin      |
       | geslachtsnaam (02.40)          | Groenen       |
       | aanduiding naamgebruik (61.10) | <naamgebruik> |
-      En die persoon heeft een 'partner' met de volgende 'naam' gegevens
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
       | naam                  | waarde |
       | geslachtsnaam (02.40) | Aedel  |
       Als personen wordt gezocht met de volgende parameters
@@ -28,7 +28,7 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
       | fields              | aanschrijfwijze                 |
-      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
       | naam                 | waarde                    |
       | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
 
@@ -43,13 +43,13 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 999992934 |
-      En die persoon heeft de volgende 'naam' gegevens
+      En de persoon heeft de volgende 'naam' gegevens
       | naam                           | waarde        |
       | voornamen (02.10)              | Franklin      |
       | voorvoegsel (02.30)            | <voorvoegsel> |
       | geslachtsnaam (02.40)          | Groenen       |
       | aanduiding naamgebruik (61.10) | <naamgebruik> |
-      En die persoon heeft een 'partner' met de volgende 'naam' gegevens
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
       | naam                  | waarde |
       | geslachtsnaam (02.40) | Aedel  |
       Als personen wordt gezocht met de volgende parameters
@@ -72,12 +72,12 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 999992934 |
-      En die persoon heeft de volgende 'naam' gegevens
+      En de persoon heeft de volgende 'naam' gegevens
       | naam                           | waarde        |
       | voornamen (02.10)              | Franklin      |
       | geslachtsnaam (02.40)          | Groenen       |
       | aanduiding naamgebruik (61.10) | <naamgebruik> |
-      En die persoon heeft een 'partner' met de volgende 'naam' gegevens
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
       | naam                  | waarde                |
       | voorvoegsel (02.30)   | <voorvoegsel partner> |
       | geslachtsnaam (02.40) | Aedel                 |
@@ -101,13 +101,13 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 999992934 |
-      En die persoon heeft alleen de volgende 'naam' gegevens
+      En de persoon heeft de volgende 'naam' gegevens
       | naam                           | waarde        |
       | voornamen (02.10)              | Franklin      |
       | voorvoegsel (02.30)            | <voorvoegsel> |
       | geslachtsnaam (02.40)          | Groenen       |
       | aanduiding naamgebruik (61.10) | <naamgebruik> |
-      En die persoon heeft een 'partner' met de volgende relevante 'naam' gegevens
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
       | naam                  | waarde                |
       | voorvoegsel (02.30)   | <voorvoegsel partner> |
       | geslachtsnaam (02.40) | Aedel                 |
@@ -116,7 +116,7 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
       | fields              | aanschrijfwijze                 |
-      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
       | naam                 | waarde                    |
       | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
 
@@ -131,11 +131,11 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       Gegeven het systeem heeft een persoon met de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 999992934 |
-      En die persoon heeft de alleen volgende 'naam' gegevens
+      En de persoon heeft de volgende 'naam' gegevens
       | naam                           | waarde          |
       | geslachtsnaam (02.40)          | <geslachtsnaam> |
       | aanduiding naamgebruik (61.10) | <naamgebruik>   |
-      En die persoon heeft een 'partner' met de volgende relevante 'naam' gegevens
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
       | naam                  | waarde |
       | voorvoegsel (02.30)   | van    |
       | geslachtsnaam (02.40) | Velzen |
@@ -144,7 +144,7 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
       | fields              | aanschrijfwijze                 |
-      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
       | naam                 | waarde                    |
       | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
 
@@ -222,8 +222,8 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
-      | fields              | aanschrijfwijze.naam            |
-      Dan heeft de response een persoon met de volgende 'adressering' naam
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
       | naam                 | waarde   |
       | aanschrijfwijze.naam | F. Aedel |
 
@@ -242,12 +242,12 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
-      | fields              | aanschrijfwijze.naam            |
-      Dan heeft de response een persoon met de volgende 'adressering' naam
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
       | naam                 | waarde   |
       | aanschrijfwijze.naam | F. Aedel |
 
-  Rule: er is geen aanschrijfwijze als de geslachtsnaam van de partner gelijk is aan de standaardwaarde en aanduiding naamgebruik is ongelijk aan "E"
+  Rule: aanduiding naamgebruik "E" (eigen naam) wordt gehanteerd als de partner geen geslachtsnaam heeft of de geslachtsnaam is gelijk aan de standaardwaarde
 
     Abstract Scenario: persoon met aanduiding naamgebruik "<naamgebruik>", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
       Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -266,34 +266,16 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
       | fields              | aanschrijfwijze                 |
-      Dan heeft de response een persoon met een leeg 'adressering' object
-
-      Voorbeelden:
-      | naamgebruik |
-      | P           |
-      | V           |
-      | N           |
-
-    Scenario: persoon met aanduiding naamgebruik "E", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
-      Gegeven het systeem heeft een persoon met de volgende gegevens
-      | naam                | waarde    |
-      | burgerservicenummer | 999992934 |
-      En de persoon heeft de volgende 'naam' gegevens
-      | naam                           | waarde   |
-      | voornamen (02.10)              | Franklin |
-      | geslachtsnaam (02.40)          | Groenen  |
-      | aanduiding naamgebruik (61.10) | E        |
-      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
-      | naam                  | waarde |
-      | geslachtsnaam (02.40) | .      |
-      Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 999992934                       |
-      | fields              | aanschrijfwijze                 |
       Dan heeft de response een persoon met de volgende 'adressering' gegevens
       | naam                 | waarde     |
       | aanschrijfwijze.naam | F. Groenen |
+
+      Voorbeelden:
+      | naamgebruik |
+      | E           |
+      | P           |
+      | V           |
+      | N           |
 
     Abstract Scenario: persoon met aanduiding naamgebruik "<naamgebruik>", heeft een partner zonder geslachtsnaam
       Gegeven het systeem heeft een persoon met de volgende gegevens
@@ -316,27 +298,50 @@ Functionaliteit: Aanschrijfwijze voor persoon met (ex-)partner, zonder adellijke
 
       Voorbeelden:
       | naamgebruik |
+      | E           |
       | P           |
       | V           |
       | N           |
 
-    Scenario: persoon met aanduiding naamgebruik "E", heeft een partner met geslachtsnaam gelijk aan standaardwaarde
+  Rule: Bij meerdere actuele (niet ontbonden) huwelijken/partnerschappen worden de naamgegevens van de eerste partner (oudste relatie) gebruikt
+
+    Abstract Scenario: persoon heeft meerdere actuele relaties
       Gegeven het systeem heeft een persoon met de volgende gegevens
-      | naam                | waarde    |
-      | burgerservicenummer | 999992934 |
+      | naam                        | waarde    |
+      | burgerservicenummer         | 999992934 |
+      | geslachtsaanduiding (04.10) | V         |
       En de persoon heeft de volgende 'naam' gegevens
-      | naam                           | waarde   |
-      | voornamen (02.10)              | Franklin |
-      | geslachtsnaam (02.40)          | Groenen  |
-      | aanduiding naamgebruik (61.10) | E        |
+      | naam                           | waarde             |
+      | geslachtsnaam (02.40)          | Groen              |
+      | voornamen (02.10)              | Ferdinand Cornelis |
+      | aanduiding naamgebruik (61.10) | V                  |
       En de persoon heeft een 'partner' met de volgende 'naam' gegevens
-      | naam              | waarde  |
-      | voornamen (02.10) | Jantine |
+      | naam                  | waarde |
+      | geslachtsnaam (02.40) | Geel   |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam                                                               | waarde            |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | <datum partner 1> |
+      En de persoon heeft een 'partner' met de volgende 'naam' gegevens
+      | naam                  | waarde |
+      | voorvoegsel (02.30)   |        |
+      | geslachtsnaam (02.40) | Roodt  |
+      En de 'partner' heeft de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam                                                               | waarde            |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | <datum partner 2> |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 999992934                       |
       | fields              | aanschrijfwijze                 |
       Dan heeft de response een persoon met de volgende 'adressering' gegevens
-      | naam                 | waarde     |
-      | aanschrijfwijze.naam | F. Groenen |
+      | naam                 | waarde      |
+      | aanschrijfwijze.naam | F.C. <naam> |
+
+      Voorbeelden:
+      | datum partner 1 | datum partner 2 | naam        | omschrijving                                                                                                                      |
+      | 19580401        | 19610808        | Geel-Groen  |                                                                                                                                   |
+      | 19580401        | 19610800        | Geel-Groen  |                                                                                                                                   |
+      | 19580401        | 19610000        | Geel-Groen  |                                                                                                                                   |
+      | 19580401        | 00000000        | Roodt-Groen | partner met datum onbekend wordt eerste partner                                                                                   |
+      | 19610800        | 19610808        | Geel-Groen  | jaar en maand zijn bekend en zijn gelijk, partner met dag onbekend wordt eerste partner                                           |
+      | 19610000        | 19610800        | Geel-Groen  | partner 1 alleen jaar bekend, partner 2 jaar en maand bekend, jaar gelijk, partner met maand en dag onbekend wordt eerste partner |

--- a/features/aanschrijfwijze-persoon-zonder-partner-met-adellijke-titel-predicaat.feature
+++ b/features/aanschrijfwijze-persoon-zonder-partner-met-adellijke-titel-predicaat.feature
@@ -1,6 +1,6 @@
 #language: nl
 
-Functionaliteit: Aanschrijfwijze voor persoon zonder (ex-)partner, zonder adellijke titel/predicaat
+Functionaliteit: Aanschrijfwijze voor persoon zonder (ex-)partner, met adellijke titel/predicaat
 
   Rule: Voor een persoon zonder (ex-)partner met adellijke titel of predicaat, wordt de naam in aanschrijfwijze als volgt samengesteld: PK VL AT VV GN
         - de adellijke titel en het predicaat wordt opgenomen in de vorm die hoort bij het geslacht van de persoon:

--- a/features/aanschrijfwijze-persoon-zonder-partner-met-adellijke-titel-predicaat.feature
+++ b/features/aanschrijfwijze-persoon-zonder-partner-met-adellijke-titel-predicaat.feature
@@ -1,0 +1,356 @@
+#language: nl
+
+Functionaliteit: Aanschrijfwijze voor persoon zonder (ex-)partner, zonder adellijke titel/predicaat
+
+  Rule: Voor een persoon zonder (ex-)partner met adellijke titel of predicaat, wordt de naam in aanschrijfwijze als volgt samengesteld: PK VL AT VV GN
+        - de adellijke titel en het predicaat wordt opgenomen in de vorm die hoort bij het geslacht van de persoon:
+          | adellijke titel/predicaat | vrouw     | man      | onbekend |
+          | JH                        | jonkvrouw | jonkheer |          |
+          | JV                        | jonkvrouw | jonkheer |          |
+          | R                         |           | ridder   |          |
+          | B                         | barones   | baron    |          |
+          | BS                        | barones   | baron    |          |
+          | H                         | hertogin  | hertog   |          |
+          | HI                        | hertogin  | hertog   |          |
+          | G                         | gravin    | graaf    |          |
+          | GI                        | gravin    | graaf    |          |
+          | M                         | markiezin | markies  |          |
+          | MI                        | markiezin | markies  |          |
+          | P                         | prinses   | prins    |          |
+          | PS                        | prinses   | prins    |          |
+        - De aanspreekvorm wordt op basis van adellijke titel/predicaat en geslacht als volgt samengesteld:
+          | adellijke titel/predicaat | vrouw                    | man                    | onbekend    |
+          | JH                        | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | JV                        | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | R                         | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | B                         | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | BS                        | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | H                         | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | HI                        | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | G                         | De hooggeboren vrouwe    | De hooggeboren heer    |             |
+          | GI                        | De hooggeboren vrouwe    | De hooggeboren heer    |             |
+          | M                         | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | MI                        | De hoogwelgeboren vrouwe | De hoogwelgeboren heer |             |
+          | P                         | De hoogheid              | De hoogheid            | De hoogheid |
+          | PS                        | De hoogheid              | De hoogheid            | De hoogheid |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "<geslacht>" en een adellijke titel die hoort bij het geslacht
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde            |
+      | geslachtsnaam (02.40)                | Groenen           |
+      | voornamen (02.10)                    | <voornamen>       |
+      | adellijke titel of predicaat (02.20) | <adellijke titel> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                          | waarde                          |
+      | aanschrijfwijze.naam          | F. <titel omschrijving> Groenen |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm>                 |
+
+      Voorbeelden:
+      | geslacht | voornamen | adellijke titel | titel omschrijving | aanspreekvorm            |
+      | M        | Franklin  | R               | ridder             | De hoogwelgeboren heer   |
+      | M        | Franklin  | B               | baron              | De hoogwelgeboren heer   |
+      | V        | Francisca | BS              | barones            | De hoogwelgeboren vrouwe |
+      | M        | Franklin  | H               | hertog             | De hoogwelgeboren heer   |
+      | V        | Francisca | HI              | hertogin           | De hoogwelgeboren vrouwe |
+      | M        | Franklin  | G               | graaf              | De hooggeboren heer      |
+      | V        | Francisca | GI              | gravin             | De hooggeboren vrouwe    |
+      | M        | Franklin  | M               | markies            | De hoogwelgeboren heer   |
+      | V        | Francisca | MI              | markiezin          | De hoogwelgeboren heer   |
+      | M        | Franklin  | P               | prins              | De hoogheid              |
+      | V        | Francisca | PS              | prinses            | De hoogheid              |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "<geslacht>" en een predicaat die hoort bij het geslacht
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde      |
+      | geslachtsnaam (02.40)                | Groenen     |
+      | voornamen (02.10)                    | <voornamen> |
+      | adellijke titel of predicaat (02.20) | <predicaat> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                          | waarde                              |
+      | aanschrijfwijze.naam          | <predicaat omschrijving> F. Groenen |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm>                     |
+
+      Voorbeelden:
+      | geslacht | voornamen | predicaat | predicaat omschrijving | aanspreekvorm            |
+      | M        | Franklin  | JH        | Jonkheer               | De hoogwelgeboren heer   |
+      | V        | Francisca | JV        | Jonkvrouw              | De hoogwelgeboren vrouwe |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "<geslacht>" en een adellijke titel die niet hoort bij het geslacht
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde            |
+      | geslachtsnaam (02.40)                | Groenen           |
+      | voornamen (02.10)                    | <voornamen>       |
+      | adellijke titel of predicaat (02.20) | <adellijke titel> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                          | waarde                          |
+      | aanschrijfwijze.naam          | F. <titel omschrijving> Groenen |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm>                 |
+
+      Voorbeelden:
+      | geslacht | voornamen | adellijke titel | titel omschrijving | aanspreekvorm            |
+      | M        | Franklin  | BS              | baron              | De hoogwelgeboren heer   |
+      | V        | Francisca | B               | barones            | De hoogwelgeboren vrouwe |
+      | M        | Franklin  | HI              | hertog             | De hoogwelgeboren heer   |
+      | V        | Francisca | H               | hertogin           | De hoogwelgeboren vrouwe |
+      | M        | Franklin  | GI              | graaf              | De hooggeboren heer      |
+      | V        | Francisca | G               | gravin             | De hooggeboren vrouwe    |
+      | M        | Franklin  | MI              | markies            | De hoogwelgeboren heer   |
+      | V        | Francisca | M               | markiezin          | De hoogwelgeboren vrouwe |
+      | M        | Franklin  | PS              | prins              | De hoogheid              |
+      | V        | Francisca | P               | prinses            | De hoogheid              |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "<geslacht>" en een predicaat die niet hoort bij het geslacht
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde      |
+      | geslachtsnaam (02.40)                | Groenen     |
+      | voornamen (02.10)                    | <voornamen> |
+      | adellijke titel of predicaat (02.20) | <predicaat> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                          | waarde                              |
+      | aanschrijfwijze.naam          | <predicaat omschrijving> F. Groenen |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm>                     |
+
+      Voorbeelden:
+      | geslacht | voornamen | predicaat | predicaat omschrijving | aanspreekvorm            |
+      | M        | Franklin  | JV        | Jonkheer               | De hoogwelgeboren heer   |
+      | V        | Francisca | JH        | Jonkvrouw              | De hoogwelgeboren vrouwe |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "O" en een adellijke titel ongelijk aan "P" of "PS"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer         | 999992934 |
+      | geslachtsaanduiding (04.10) | O         |
+      En die persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde            |
+      | geslachtsnaam (02.40)                | Groenen           |
+      | voornamen (02.10)                    | <voornamen>       |
+      | adellijke titel of predicaat (02.20) | <adellijke titel> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde     |
+      | aanschrijfwijze.naam | F. Groenen |
+
+      Voorbeelden:
+      | voornamen | adellijke titel |
+      | Franklin  | B               |
+      | Francisca | GI              |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "O" en een predicaat
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer         | 999992934 |
+      | geslachtsaanduiding (04.10) | O         |
+      En die persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde      |
+      | geslachtsnaam (02.40)                | Groenen     |
+      | voornamen (02.10)                    | <voornamen> |
+      | adellijke titel of predicaat (02.20) | <predicaat> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde     |
+      | aanschrijfwijze.naam | F. Groenen |
+
+      Voorbeelden:
+      | voornamen | adellijke titel |
+      | Franklin  | JH              |
+      | Francisca | JV              |
+
+    Abstract Scenario: persoon zonder voorvoegsel, heeft geslacht "O" en adellijke titel gelijk aan "P" of "PS"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer         | 999992934 |
+      | geslachtsaanduiding (04.10) | O         |
+      En die persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde            |
+      | geslachtsnaam (02.40)                | Groenen           |
+      | voornamen (02.10)                    | <voornamen>       |
+      | adellijke titel of predicaat (02.20) | <adellijke titel> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                          | waarde      |
+      | aanschrijfwijze.naam          | F. Groenen  |
+      | aanschrijfwijze.aanspreekvorm | De hoogheid |
+
+      Voorbeelden:
+      | voornamen | adellijke titel |
+      | Franklin  | P               |
+      | Francisca | PS              |
+
+    Scenario: persoon met geslacht "V", heeft adellijke titel "R"
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer         | 999992934 |
+      | geslachtsaanduiding (04.10) | V         |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde    |
+      | geslachtsnaam (02.40)                | Groenen   |
+      | voornamen (02.10)                    | Francisca |
+      | adellijke titel of predicaat (02.20) | R         |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                          | waarde                   |
+      | aanschrijfwijze.naam          | F. Groenen               |
+      | aanschrijfwijze.aanspreekvorm | De hoogwelgeboren vrouwe |
+
+  Rule: voorvoegsel wordt gebruikt zoals het is geregistreerd
+
+    Abstract Scenario: persoon met voorvoegsel, heeft geslacht "<geslacht>" en een adellijke titel
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde            |
+      | voorvoegsel (02.30)                  | <voorvoegsel>     |
+      | geslachtsnaam (02.40)                | Aedel             |
+      | voornamen (02.10)                    | <voornamen>       |
+      | adellijke titel of predicaat (02.20) | <adellijke titel> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met de volgende 'adressering' gegevens
+      | naam                          | waarde                                      |
+      | aanschrijfwijze.naam          | F. <titel omschrijving> <voorvoegsel> Aedel |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm>                             |
+
+      Voorbeelden:
+      | geslacht | voornamen | voorvoegsel | adellijke titel | titel omschrijving | aanspreekvorm            |
+      | M        | Franklin  | Van Den     | R               | ridder             | De hoogwelgeboren heer   |
+      | M        | Franklin  | van den     | B               | baron              | De hoogwelgeboren heer   |
+      | M        | Franklin  | van         | GI              | graaf              | De hooggeboren heer      |
+      | V        | Francisca | Van         | B               | barones            | De hoogwelgeboren vrouwe |
+      | M        | Franklin  | van den     | P               | prins              | De hoogheid              |
+      | V        | Francisca | van den     | PS              | prinses            | De hoogheid              |
+
+  Rule: de eerste naamcomponent in de naam in aanschrijfwijze begint met een hoofdletter
+
+    Abstract Scenario: persoon heeft een naamketen (alleen geslachtsnaam) en een adellijke titel
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En die persoon heeft alleen de volgende 'naam' gegevens
+      | naam                                 | waarde            |
+      | geslachtsnaam (02.40)                | Ali bin Mohammed  |
+      | adellijke titel of predicaat (02.20) | <adellijke titel> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                          | waarde                                |
+      | aanschrijfwijze.naam          | <titel omschrijving> Ali bin Mohammed |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm>                       |
+
+      Voorbeelden:
+      | geslacht | adellijke titel | titel omschrijving | aanspreekvorm            |
+      | M        | B               | Baron              | De hoogwelgeboren heer   |
+      | V        | HI              | Hertogin           | De hoogwelgeboren vrouwe |
+      | M        | GI              | Graaf              | De hooggeboren heer      |
+      | V        | P               | Prinses            | De hoogheid              |
+
+    Abstract Scenario: persoon zonder voornamen heeft een adellijke titel of predicaat
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde    |
+      | burgerservicenummer         | 999992934 |
+      | geslachtsaanduiding (04.10) | M         |
+      En die persoon heeft alleen de volgende 'naam' gegevens
+      | naam                                 | waarde               |
+      | voorvoegsel (02.30)                  | van den              |
+      | geslachtsnaam (02.40)                | Aedel                |
+      | adellijke titel of predicaat (02.20) | <titel of predicaat> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                          | waarde                                          |
+      | aanschrijfwijze.naam          | <titel of predicaat omschrijving> van den Aedel |
+      | aanschrijfwijze.aanspreekvorm | De hoogwelgeboren heer                          |
+
+      Voorbeelden:
+      | titel of predicaat | titel of predicaat omschrijving |
+      | M                  | Markies                         |
+      | JH                 | Jonkheer                        |
+
+  Rule: er is geen naam in aanschrijfwijze als de geslachtsnaam van de persoon gelijk is aan de standaardwaarde
+
+    Scenario: persoon met adellijke titel of predicaat heeft een geslachtsnaam met standaardwaarde
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                        | waarde     |
+      | burgerservicenummer         | 999992934  |
+      | geslachtsaanduiding (04.10) | <geslacht> |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                                 | waarde               |
+      | voornamen (02.10)                    | <voornamen>          |
+      | geslachtsnaam (02.40)                | .                    |
+      | adellijke titel of predicaat (02.20) | <titel of predicaat> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                          | waarde          |
+      | aanschrijfwijze.aanspreekvorm | <aanspreekvorm> |
+
+      Voorbeelden:
+      | geslacht | voornamen | titel of predicaat | aanspreekvorm            |
+      | M        | Franklin  | G                  | De hooggeboren heer      |
+      | V        | Francisca | BI                 | De hoogwelgeboren vrouwe |

--- a/features/aanschrijfwijze-persoon-zonder-partner-zonder-adellijke-titel-predicaat.feature
+++ b/features/aanschrijfwijze-persoon-zonder-partner-zonder-adellijke-titel-predicaat.feature
@@ -1,0 +1,139 @@
+#language: nl
+
+Functionaliteit: Aanschrijfwijze voor persoon zonder (ex-)partner, zonder adellijke titel/predicaat
+
+  Rule: Voor een persoon zonder (ex-)partner, zonder adellijke titel of predicaat,
+        wordt de naam in aanschrijfwijze als volgt samengesteld: VL VV GN
+
+    Scenario: persoon heeft geen voorvoegsel
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft alleen de volgende 'naam' gegevens
+      | naam                  | waarde   |
+      | geslachtsnaam (02.40) | Groenen  |
+      | voornamen (02.10)     | Franklin |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde     |
+      | aanschrijfwijze.naam | F. Groenen |
+
+    Scenario: persoon heeft een naamketen (alleen geslachtsnaam)
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft alleen de volgende 'naam' gegevens
+      | naam                  | waarde           |
+      | geslachtsnaam (02.40) | Ali bin Mohammed |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde           |
+      | aanschrijfwijze.naam | Ali bin Mohammed |
+
+  Rule: voorvoegsel wordt gebruikt zoals het is geregistreerd
+
+    Abstract Scenario: persoon heeft voorvoegsel
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En die persoon heeft alleen de volgende 'naam' gegevens
+      | naam                  | waarde        |
+      | voorvoegsel (02.30)   | <voorvoegsel> |
+      | geslachtsnaam (02.40) | Groenen       |
+      | voornamen (02.10)     | Franklin      |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde                   |
+      | aanschrijfwijze.naam | F. <voorvoegsel> Groenen |
+
+      Voorbeelden:
+      | voorvoegsel |
+      | van         |
+      | Van         |
+      | in het      |
+      | In Den      |
+
+  Rule: de eerste naamcomponent in de naam in aanschrijfwijze begint met een hoofdletter
+
+    Scenario: persoon heeft geen voorvoegsel en geen voornamen
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft alleen de volgende 'naam' gegevens
+      | naam                  | waarde  |
+      | geslachtsnaam (02.40) | Groenen |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde  |
+      | aanschrijfwijze.naam | Groenen |
+
+    Abstract Scenario: persoon met voorvoegsel, heeft geen voornamen
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft alleen de volgende 'naam' gegevens
+      | naam                  | waarde        |
+      | voorvoegsel (02.30)   | <voorvoegsel> |
+      | geslachtsnaam (02.40) | Groenen       |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze                 |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde                    |
+      | aanschrijfwijze.naam | <naam in aanschrijfwijze> |
+
+      Voorbeelden:
+      | voorvoegsel | naam in aanschrijfwijze |
+      | van         | Van Groenen             |
+      | Van         | Van Groenen             |
+      | in het      | In het Groenen          |
+      | In Den      | In Den Groenen          |
+
+  Rule: er is geen aanschrijfwijze als de geslachtsnaam van de persoon gelijk is aan de standaardwaarde
+
+    Scenario: persoon heeft een geslachtsnaam met standaardwaarde
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                  | waarde          |
+      | voornamen (02.10)     | Franklin |
+      | geslachtsnaam (02.40) | . |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze            |
+      Dan heeft de response een persoon met een leeg 'adressering' object
+
+    Scenario: persoon heeft geen geslachtsnaam
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 999992934 |
+      En de persoon heeft de volgende 'naam' gegevens
+      | naam                  | waarde          |
+      | voornamen (02.10)     | Franklin |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 999992934                       |
+      | fields              | aanschrijfwijze            |
+      Dan heeft de response een persoon met een leeg 'adressering' object


### PR DESCRIPTION
- scenario's gesplitst over meerdere feature files
- geprobeerd scenario's meer readable te maken door ze explicieter te maken. Consequentie hiervan is dat er meer duplicaten zijn die vroeger met een abstract scenario werden samengevoegd
- nog geen begeleidende teksten in de feature files
- nog geen scenario's voor personen met partner met adellijke titel of predicaat