### PR TITLE
Verblijfstitel 00 98

### DIFF
--- a/features/onbekend_waardes.feature
+++ b/features/onbekend_waardes.feature
@@ -130,7 +130,6 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
   | verblijfplaats.gemeenteVanInschrijving      | 0000            |
   | verblijfplaats.land                         | 0000            |
   | verblijfplaats.landVanwaarIngeschreven      | 0000            |
-  | verblijfstitel.aanduiding                   | 00              |
   | ouders.geboorte.plaats                      | 0000            |
   | ouders.geboorte.land                        | 0000            |
   | partners.geboorte.plaats                    | 0000            |
@@ -162,7 +161,6 @@ Rule: een veld van type Waardetabel wordt niet opgenomen wanneer de code de onbe
     | geboorte       | land       | geboorteland (03.30)              | 0000   |
     | overlijden     | plaats     | plaats overlijden (08.20)         | 0000   |
     | overlijden     | land       | land overlijden (08.30)           | 0000   |
-    | verblijfstitel | aanduiding | aanduiding verblijfstitel (39.10) | 00     |
 
   Abstract Scenario: onbekend waarde voor: <element>
     Gegeven het systeem heeft een persoon met de volgende gegevens

--- a/features/verblijfstitel.feature
+++ b/features/verblijfstitel.feature
@@ -74,3 +74,27 @@ Functionaliteit: Verblijfstitel
       Dan heeft de response een persoon met alleen de volgende gegevens
       | naam                | waarde    |
       | burgerservicenummer | 555550003 |
+
+  Rule: Een verblijfstitel met onbekende aanduiding wordt wel geleverd
+
+    Scenario: persoon heeft verblijfstitel maar het is nog onbekend welke
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550004 |
+      En de persoon heeft de volgende 'verblijfstitel' gegevens
+      | naam                                | waarde   |
+      | Aanduiding verblijfstitel (39.10)   | 00       |
+      | aanduiding.omschrijving             | Onbekend |
+      | Ingangsdatum verblijfstitel (39.30) | 20210714 |
+      Als personen op '5 juni 2022' wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 555550004                       |
+      | fields              | verblijfstitel                  |
+      Dan heeft de response een persoon met alleen de volgende 'verblijfstitel' gegevens
+      | naam                    | waarde       |
+      | aanduiding.code         | 00           |
+      | aanduiding.omschrijving | Onbekend     |
+      | datumIngang.type        | Datum        |
+      | datumIngang.datum       | 2021-07-14   |
+      | datumIngang.langFormaat | 14 juli 2021 |

--- a/features/verblijfstitel.feature
+++ b/features/verblijfstitel.feature
@@ -13,10 +13,10 @@ Functionaliteit: Verblijfstitel
       | naam                | waarde    |
       | burgerservicenummer | 555550001 |
       En de persoon heeft de volgende 'verblijfstitel' gegevens
-      | naam                              | waarde       |
-      | Aanduiding verblijfstitel (39.10) | 37           |
-      | Datum einde verblijfstitel        | <datumEinde> |
-      | Ingangsdatum verblijfstitel       | 20210315     |
+      | naam                                | waarde       |
+      | Aanduiding verblijfstitel (39.10)   | 37           |
+      | Datum einde verblijfstitel (39.20)  | <datumEinde> |
+      | Ingangsdatum verblijfstitel (39.30) | 20210315     |
       Als personen op '5 juni 2022' wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -38,10 +38,10 @@ Functionaliteit: Verblijfstitel
       | naam                | waarde    |
       | burgerservicenummer | 555550002 |
       En de persoon heeft de volgende 'verblijfstitel' gegevens
-      | naam                              | waarde       |
-      | Aanduiding verblijfstitel (39.10) | 37           |
-      | Datum einde verblijfstitel        | <datumEinde> |
-      | Ingangsdatum verblijfstitel       | 20210315     |
+      | naam                                | waarde       |
+      | Aanduiding verblijfstitel (39.10)   | 37           |
+      | Datum einde verblijfstitel (39.20)  | <datumEinde> |
+      | Ingangsdatum verblijfstitel (39.30) | 20210315     |
       Als personen op '5 juni 2022' wordt gezocht met de volgende parameters
       | naam                | waarde                                             |
       | type                | RaadpleegMetBurgerservicenummer                    |
@@ -55,3 +55,22 @@ Functionaliteit: Verblijfstitel
       | titel                       | datumEinde |
       | datum einde is vandaag      | 20220605   |
       | datum einde in het verleden | 20220315   |
+
+  Rule: een verblijfstitel met aanduiding 98 "geen verblijfstitel (meer)" wordt niet opgenomen
+
+    Scenario: vervallen verblijfstitel
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |
+      En de persoon heeft de volgende 'verblijfstitel' gegevens
+      | naam                                | waarde   |
+      | Aanduiding verblijfstitel (39.10)   | 98       |
+      | Ingangsdatum verblijfstitel (39.30) | 20210315 |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                                        |
+      | type                | RaadpleegMetBurgerservicenummer               |
+      | burgerservicenummer | 555550003                                     |
+      | fields              | burgerservicenummer,verblijfstitel.aanduiding |
+      Dan heeft de response een persoon met alleen de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 555550003 |


### PR DESCRIPTION
Closes #1200 

- verblijfstitel aanduiding 00 (onbekend) moet wel geleverd worden, zodat expliciet duidelijk wordt dat het soort verblijfstitel onbekend is >>>> verwijderd uit onbekend_waardes.feature
- verblijfstitel met aanduiding 98 (geen verblijfstitel meer) moet in zijn geheel niet geleverd worden, zodat niet de suggestie kan worden gewekt dat er wel een verblijfstitel is >>>> toegevoegd aan verblijfstitel.feature

daarnaast correctie gedaan door toevoegen elementnummers aan datum einde en ingangsdatum verblijfstitel in Gegeven stappen