### PR TITLE
correctie kiesrecht feature met lege aanduiding en wel einddatum

### DIFF
--- a/features/gba-dev/uitsluiting-kiesrecht.feature
+++ b/features/gba-dev/uitsluiting-kiesrecht.feature
@@ -7,14 +7,15 @@ Functionaliteit: Uitsluiting kiesrecht
 	Abstract Scenario: Geen aanduiding uitgesloten kiesrecht (38.10) wel een einddatum uitsluiting kiesrecht
 	  Gegeven het systeem heeft een persoon met de volgende gegevens
 		| naam                        | waarde     |
-		| burgerservicenummer         | 999990001  |
+		| burgerservicenummer         | 000000085  |
     En de persoon heeft de volgende kiesrecht gegevens
-    | einddatum uitsluiting kiesrecht (38.20) | 20300101 |
-		Als de persoon op 15 maart 2022 wordt geraadpleegd met de volgende parameters
+		| naam                                    | waarde   |
+		| einddatum uitsluiting kiesrecht (38.20) | 20300101 |
+		Als personen wordt gezocht met de volgende parameters
 		| naam                | waarde                          |
 		| type                | RaadpleegMetBurgerservicenummer |
-		| burgerservicenummer | 999990001                       |
+		| burgerservicenummer | 000000085                       |
 		| fields              | uitsluitingKiesrecht            |
-		Dan bevat de persoon met burgerservicenummer '999990001' de volgende 'uitsluitingKiesrecht' gegevens
+		Dan bevat de persoon met burgerservicenummer '000000085' de volgende 'uitsluitingKiesrecht' gegevens
     | naam      | waarde   |
     | einddatum | 20300101 |

--- a/features/gba-dev/uitsluiting-kiesrecht.feature
+++ b/features/gba-dev/uitsluiting-kiesrecht.feature
@@ -1,0 +1,20 @@
+# language: nl
+
+Functionaliteit: Uitsluiting kiesrecht
+
+
+	@gba
+	Abstract Scenario: Geen aanduiding uitgesloten kiesrecht (38.10) wel een einddatum uitsluiting kiesrecht
+	  Gegeven het systeem heeft een persoon met de volgende gegevens
+		| naam                        | waarde     |
+		| burgerservicenummer         | 999990001  |
+    En de persoon heeft de volgende kiesrecht gegevens
+    | einddatum uitsluiting kiesrecht (38.20) | 20300101 |
+		Als de persoon op 15 maart 2022 wordt geraadpleegd met de volgende parameters
+		| naam                | waarde                          |
+		| type                | RaadpleegMetBurgerservicenummer |
+		| burgerservicenummer | 999990001                       |
+		| fields              | uitsluitingKiesrecht            |
+		Dan bevat de persoon met burgerservicenummer '999990001' de volgende 'uitsluitingKiesrecht' gegevens
+    | naam      | waarde   |
+    | einddatum | 20300101 |

--- a/features/kiesrecht.feature
+++ b/features/kiesrecht.feature
@@ -12,28 +12,20 @@ Rule: Aanduiding uitgesloten kiesrecht (38.10) wordt geleverd als boolean
 	- waarde "A" wordt geleverd als boolean waarde true
 
 	@gba
-	Abstract Scenario: Aanduiding uitgesloten kiesrecht (38.10) <uitsluiting kiesrecht> vertaald naar boolean
+	Scenario: Aanduiding uitgesloten kiesrecht (38.10) "A" vertaald naar boolean true
 	  Gegeven het systeem heeft een persoon met de volgende gegevens
 		| naam                        | waarde     |
 		| burgerservicenummer         | 999990001  |
 		En de persoon heeft de volgende kiesrecht gegevens
-		| aanduiding uitgesloten kiesrecht (38.10) | <uitgesloten kiesrecht> |
-		| einddatum uitsluiting kiesrecht (38.20)  | 20300101                |
+		| aanduiding uitgesloten kiesrecht (38.10) | A |
 		Als de persoon op 15 maart 2022 wordt geraadpleegd met de volgende parameters
 		| naam                | waarde                          |
 		| type                | RaadpleegMetBurgerservicenummer |
 		| burgerservicenummer | 999990001                       |
 		| fields              | uitsluitingKiesrecht            |
 		Dan bevat de persoon met burgerservicenummer '999990001' de volgende 'uitsluitingKiesrecht' gegevens
-		| naam                          | waarde                    |
-		| uitgeslotenVanKiesrecht       | <uitgeslotenVanKiesrecht> |
-		| einddatum                     | 2030-01-01                |
-
-		Voorbeelden:
-		| uitgesloten kiesrecht | uitgeslotenVanKiesrecht |
-		| A                     | true                    |
-		|                       |                         |
-
+		| naam                    | waarde |
+		| uitgeslotenVanKiesrecht | true   |
 
 
 @gba

--- a/features/kiesrecht.feature
+++ b/features/kiesrecht.feature
@@ -13,17 +13,15 @@ Rule: Aanduiding uitgesloten kiesrecht (38.10) wordt geleverd als boolean
 
 	@gba
 	Scenario: Aanduiding uitgesloten kiesrecht (38.10) "A" vertaald naar boolean true
-	  Gegeven het systeem heeft een persoon met de volgende gegevens
-		| naam                        | waarde     |
-		| burgerservicenummer         | 999990001  |
-		En de persoon heeft de volgende kiesrecht gegevens
-		| aanduiding uitgesloten kiesrecht (38.10) | A |
+	  Gegeven de persoon met burgerservicenummer '000000012' heeft de volgende 'kiesrecht' gegevens
+		| naam                                     | waarde |
+		| aanduiding uitgesloten kiesrecht (38.10) | A      |
 		Als de persoon op 15 maart 2022 wordt geraadpleegd met de volgende parameters
 		| naam                | waarde                          |
 		| type                | RaadpleegMetBurgerservicenummer |
-		| burgerservicenummer | 999990001                       |
+		| burgerservicenummer | 000000012                       |
 		| fields              | uitsluitingKiesrecht            |
-		Dan bevat de persoon met burgerservicenummer '999990001' de volgende 'uitsluitingKiesrecht' gegevens
+		Dan bevat de persoon met burgerservicenummer '000000012' de volgende 'uitsluitingKiesrecht' gegevens
 		| naam                    | waarde |
 		| uitgeslotenVanKiesrecht | true   |
 
@@ -38,19 +36,16 @@ Rule: Uitsluiting van Europees kiesrecht wordt alleen opgenomen wanneer de eindd
 
 	@gba
 	Abstract Scenario: Europees kiesrecht <omschrijving>
-		Gegeven het systeem heeft een persoon met de volgende gegevens
-		| naam                        | waarde     |
-		| burgerservicenummer         | 999990001  |
-		En de persoon heeft de volgende 'kiesrecht' gegevens
+		Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'kiesrecht' gegevens
 		| naam                                             | waarde                  |
 		| Europees kiesrecht (31.10)                       | <Europees kiesrecht>    |
 		| einddatum uitsluiting Europees kiesrecht (31.30) | <einddatum uitsluiting> |
 		Als de persoon op 15 maart 2022 wordt geraadpleegd met de volgende parameters
 		| naam                | waarde                          |
 		| type                | RaadpleegMetBurgerservicenummer |
-		| burgerservicenummer | 999990001                       |
+		| burgerservicenummer | 000000024                       |
 		| fields              | europeesKiesrecht                       |
-		Dan bevat de persoon met burgerservicenummer '999990001' de volgende 'europeesKiesrecht' gegevens
+		Dan bevat de persoon met burgerservicenummer '000000024' de volgende 'europeesKiesrecht' gegevens
 		| naam                             | waarde                    |
 		| aanduiding.code                  | <aanduiding.code          |
 		| aanduiding.omschrijving          | omschrijving.omschrijving |
@@ -81,19 +76,16 @@ Rule: Uitsluiting van kiesrecht wordt alleen opgenomen wanneer de einddatum uits
 
 	@gba
 	Abstract Scenario: kiesrecht <omschrijving>
-		Gegeven het systeem heeft een persoon met de volgende gegevens
-		| naam                        | waarde     |
-		| burgerservicenummer         | 999990001  |
-		En de persoon heeft de volgende 'kiesrecht' gegevens
+		Gegeven de persoon met burgerservicenummer '000000036' heeft de volgende 'kiesrecht' gegevens
 		| naam                                     | waarde                  |
 		| aanduiding uitgesloten kiesrecht (38.10) | <uitsluiting kiesrecht> |
 		| einddatumUitsluitingKiesrecht (38.20)    | <einddatum uitsluiting> |
 		Als de persoon op 15 maart 2022 wordt geraadpleegd met de volgende parameters
 		| naam                | waarde                          |
 		| type                | RaadpleegMetBurgerservicenummer |
-		| burgerservicenummer | 999990001                       |
+		| burgerservicenummer | 000000036                       |
 		| fields              | uitsluitingKiesrecht                       |
-		Dan bevat de persoon met burgerservicenummer '999990001' de volgende 'uitsluitingKiesrecht' gegevens
+		Dan bevat de persoon met burgerservicenummer '000000036' de volgende 'uitsluitingKiesrecht' gegevens
 		| naam                    | waarde                    |
 		| uitgeslotenVanKiesrecht | <uitgeslotenVanKiesrecht> |
 		| einddatum               | <einddatum>               |


### PR DESCRIPTION
- in nieuwe map gba-dev nieuw scenario toegevoegd voor de situatie dat aanduiding uitsluiting kiesrecht niet gevuld is, maar wel een einddatum uitsluiting kiesrecht
- deze situatie verwijderd uit eerste kiesrecht scenario

in gba-dev beschreven scenario hoort functioneel niet voor te komen, dus hoort niet in algemene feature (die gericht is op afnemers).
abstract scenario was niet duidelijk over wat lege kolomcellen betekenen (niet leveren, of leveren als null of als lege string, of ...)