### PR TITLE
correctie mapping leeftijd - toevoegen overlijden

### DIFF
--- a/features/gba-dev/fields-mapping-gba.csv
+++ b/features/gba-dev/fields-mapping-gba.csv
@@ -60,7 +60,7 @@ kinderen.naam.inOnderzoek.voorletters,kinderen.inOnderzoek
 kinderen.naam.inOnderzoek.voornamen,kinderen.inOnderzoek
 kinderen.naam.inOnderzoek.voorvoegsel,kinderen.inOnderzoek
 kinderen.naam.voorletters,kinderen.naam.voornamen
-leeftijd,geboorte.datum
+leeftijd,geboorte.datum|overlijden.datum
 naam.inOnderzoek,persoonInOnderzoek
 naam.inOnderzoek.aanduidingNaamgebruik,persoonInOnderzoek
 naam.inOnderzoek.adellijkeTitelPredicaat,persoonInOnderzoek


### PR DESCRIPTION
bij vragen leeftijd moet ook overlijden.datum geleverd worden, omdat leeftijd niet geleverd mag worden op een overleden persoon