### PR TITLE
Feature bag identificaties

### DIFF
--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -13,14 +13,14 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | datum aanvang adreshouding (10.30) | 20150808 |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
       | naam                                       | waarde                |
-      | gemeente van inschrijving (09.10)          | <gemeente code>       |
+      | gemeente_code                              | <gemeente code>       |
       | straatnaam (11.10)                         | Kromme dijk           |
       | huisnummer (11.20)                         | 15                    |
       | postcode (11.60)                           | 1001XX                |
       | woonplaatsnaam (11.70)                     | Testdorp              |
       | identificatiecode verblijfplaats (11.80)   | <verblijfplaats id>   |
       | identificatiecode nummeraanduiding (11.90) | <nummeraanduiding id> |
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                                                                  |
       | type                | RaadpleegMetBurgerservicenummer                                         |
       | burgerservicenummer | 000000024                                                               |
@@ -42,14 +42,14 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | datum aanvang adreshouding (10.30) | 20150808 |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
       | naam                                       | waarde           |
-      | gemeente van inschrijving (09.10)          | 0363             |
+      | gemeente_code                              | 0363             |
       | straatnaam (11.10)                         | Kromme dijk      |
       | huisnummer (11.20)                         | 15               |
       | postcode (11.60)                           | 1001XX           |
       | woonplaatsnaam (11.70)                     | Testdorp         |
       | identificatiecode verblijfplaats (11.80)   | 0363010000123456 |
       | identificatiecode nummeraanduiding (11.90) | 0363200000123456 |
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                                                                  |
       | type                | RaadpleegMetBurgerservicenummer                                         |
       | burgerservicenummer | 000000024                                                               |

--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -17,7 +17,7 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | straatnaam (11.10)                         | Kromme dijk           |
       | huisnummer (11.20)                         | 15                    |
       | postcode (11.60)                           | 1001XX                |
-      | woonplaatsnaam (11.70)                     | Testdorp              |
+      | woonplaats (11.70)                         | Testdorp              |
       | identificatiecode verblijfplaats (11.80)   | <verblijfplaats id>   |
       | identificatiecode nummeraanduiding (11.90) | <nummeraanduiding id> |
       Als gba personen wordt gezocht met de volgende parameters
@@ -46,7 +46,7 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | straatnaam (11.10)                         | Kromme dijk      |
       | huisnummer (11.20)                         | 15               |
       | postcode (11.60)                           | 1001XX           |
-      | woonplaatsnaam (11.70)                     | Testdorp         |
+      | woonplaats (11.70)                         | Testdorp         |
       | identificatiecode verblijfplaats (11.80)   | 0363010000123456 |
       | identificatiecode nummeraanduiding (11.90) | 0363200000123456 |
       Als gba personen wordt gezocht met de volgende parameters

--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -1,0 +1,60 @@
+#language: nl
+
+@gba
+Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificaties moet niet geleverd worden
+  BAG-identificaties identificatiecode verblijfplaats (11.80) en identificatiecode nummeraanduiding (11.90) moeten bestaan uit exact 16 cijfers
+
+  Het kan nu nog voorkomen dat deze identificaties zijn opgeslagen als getal, waardoor de voorloopnul(len) zijn weggevallen.
+  In de BRP-V bron wordt dit dan opgeslagen door de waarde aan te vullen met spaties tot het 16 tekens lang is.
+
+    Abstract Scenario: BAG-identificaties bestaan uit <omschrijving> 
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | naam                                       | waarde                |
+      | straatnaam (11.10)                         | Kromme dijk           |
+      | huisnummer (11.20)                         | 15                    |
+      | postcode (11.60)                           | 1001XX                |
+      | woonplaatsnaam (11.70)                     | Testdorp              |
+      | identificatiecode verblijfplaats (11.80)   | <verblijfplaats id>   |
+      | identificatiecode nummeraanduiding (11.90) | <nummeraanduiding id> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                                                                                                               |
+      | type                | RaadpleegMetBurgerservicenummer                                                                                      |
+      | burgerservicenummer | 000000024                                                                                                            |
+      | fields              | verblijfplaats.postcode,verblijfplaats.nummeraanduidingIdentificatie,verblijfplaats.adresseerbaarObjectIdentificatie |
+      Dan heeft de response een persoon met alleen de volgende 'verblijfplaats' gegevens
+      | naam     | waarde |
+      | type     | Adres  |
+      | postcode | 1001XX |
+
+      Voorbeelden:
+      | omschrijving                 | verblijfplaats id | nummeraanduiding id |
+      | 14 cijfers plus twee spaties | 24010000123456    | 24200000123456      |
+      | 15 cijfers plus een spatie   | 363010000123456   | 363200000123456     |
+      | cijfers en een letter        | 03630V0000123456  | 0363NA0000123456    |
+
+    Scenario: BAG-identificaties bestaan uit 16 cijfers
+      Gegeven het systeem heeft een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | naam                                       | waarde           |
+      | straatnaam (11.10)                         | Kromme dijk      |
+      | huisnummer (11.20)                         | 15               |
+      | postcode (11.60)                           | 1001XX           |
+      | woonplaatsnaam (11.70)                     | Testdorp         |
+      | identificatiecode verblijfplaats (11.80)   | 0363010000123456 |
+      | identificatiecode nummeraanduiding (11.90) | 0363200000123456 |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                                                                                                               |
+      | type                | RaadpleegMetBurgerservicenummer                                                                                      |
+      | burgerservicenummer | 000000024                                                                                                            |
+      | fields              | verblijfplaats.postcode,verblijfplaats.nummeraanduidingIdentificatie,verblijfplaats.adresseerbaarObjectIdentificatie |
+      Dan heeft de response een persoon met alleen de volgende 'verblijfplaats' gegevens
+      | naam                             | waarde           |
+      | type                             | Adres            |
+      | postcode                         | 1001XX           |
+      | adresseerbaarObjectIdentificatie | 0363010000123456 |
+      | nummeraanduidingIdentificatie    | 0363200000123456 |

--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -1,7 +1,6 @@
 #language: nl
 
-@gba
-Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificaties moet niet geleverd worden
+Functionaliteit: BAG-identificatie met waarde die niet voldoet aan de specificatie moet niet geleverd worden
   BAG-identificaties identificatiecode verblijfplaats (11.80) en identificatiecode nummeraanduiding (11.90) moeten bestaan uit exact 16 cijfers
 
   Het kan nu nog voorkomen dat deze identificaties zijn opgeslagen als getal, waardoor de voorloopnul(len) zijn weggevallen.
@@ -27,7 +26,6 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | fields              | postcode,nummeraanduidingIdentificatie,adresseerbaarObjectIdentificatie |
       Dan heeft de response een persoon met alleen de volgende 'verblijfplaats' gegevens
       | naam     | waarde |
-      | type     | Adres  |
       | postcode | 1001XX |
 
       Voorbeelden:
@@ -56,7 +54,6 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | fields              | postcode,nummeraanduidingIdentificatie,adresseerbaarObjectIdentificatie |
       Dan heeft de response een persoon met alleen de volgende 'verblijfplaats' gegevens
       | naam                             | waarde           |
-      | type                             | Adres            |
       | postcode                         | 1001XX           |
       | adresseerbaarObjectIdentificatie | 0363010000123456 |
       | nummeraanduidingIdentificatie    | 0363200000123456 |

--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -13,6 +13,7 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | datum aanvang adreshouding (10.30) | 20150808 |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
       | naam                                       | waarde                |
+      | gemeente van inschrijving (09.10)          | <gemeente code>       |
       | straatnaam (11.10)                         | Kromme dijk           |
       | huisnummer (11.20)                         | 15                    |
       | postcode (11.60)                           | 1001XX                |
@@ -30,10 +31,10 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | postcode | 1001XX |
 
       Voorbeelden:
-      | omschrijving                 | verblijfplaats id | nummeraanduiding id |
-      | 14 cijfers plus twee spaties | 24010000123456    | 24200000123456      |
-      | 15 cijfers plus een spatie   | 363010000123456   | 363200000123456     |
-      | cijfers en een letter        | 03630V0000123456  | 0363NA0000123456    |
+      | omschrijving                 | gemeente code | verblijfplaats id | nummeraanduiding id |
+      | 14 cijfers plus twee spaties | 0024          | 24010000123456    | 24200000123456      |
+      | 15 cijfers plus een spatie   | 0363          | 363010000123456   | 363200000123456     |
+      | cijfers en een letter        | 0363          | 03630V0000123456  | 0363NA0000123456    |
 
     Scenario: BAG-identificaties bestaan uit 16 cijfers
       Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
@@ -41,6 +42,7 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | datum aanvang adreshouding (10.30) | 20150808 |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
       | naam                                       | waarde           |
+      | gemeente van inschrijving (09.10)          | 0363             |
       | straatnaam (11.10)                         | Kromme dijk      |
       | huisnummer (11.20)                         | 15               |
       | postcode (11.60)                           | 1001XX           |

--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -7,11 +7,11 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
   Het kan nu nog voorkomen dat deze identificaties zijn opgeslagen als getal, waardoor de voorloopnul(len) zijn weggevallen.
   In de BRP-V bron wordt dit dan opgeslagen door de waarde aan te vullen met spaties tot het 16 tekens lang is.
 
-    Abstract Scenario: BAG-identificaties bestaan uit <omschrijving> 
-      Gegeven het systeem heeft een persoon met de volgende gegevens
-      | naam                | waarde    |
-      | burgerservicenummer | 000000024 |
-      En de persoon heeft de volgende 'verblijfplaats' gegevens
+    Abstract Scenario: BAG-identificaties bestaan uit <omschrijving>
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | naam                               | waarde   |
+      | datum aanvang adreshouding (10.30) | 20150808 |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
       | naam                                       | waarde                |
       | straatnaam (11.10)                         | Kromme dijk           |
       | huisnummer (11.20)                         | 15                    |
@@ -36,10 +36,10 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | cijfers en een letter        | 03630V0000123456  | 0363NA0000123456    |
 
     Scenario: BAG-identificaties bestaan uit 16 cijfers
-      Gegeven het systeem heeft een persoon met de volgende gegevens
-      | naam                | waarde    |
-      | burgerservicenummer | 000000024 |
-      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | naam                               | waarde   |
+      | datum aanvang adreshouding (10.30) | 20150808 |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
       | naam                                       | waarde           |
       | straatnaam (11.10)                         | Kromme dijk      |
       | huisnummer (11.20)                         | 15               |

--- a/features/gba-dev/bag-identificatie.feature
+++ b/features/gba-dev/bag-identificatie.feature
@@ -20,10 +20,10 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | identificatiecode verblijfplaats (11.80)   | <verblijfplaats id>   |
       | identificatiecode nummeraanduiding (11.90) | <nummeraanduiding id> |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                                                                                                               |
-      | type                | RaadpleegMetBurgerservicenummer                                                                                      |
-      | burgerservicenummer | 000000024                                                                                                            |
-      | fields              | verblijfplaats.postcode,verblijfplaats.nummeraanduidingIdentificatie,verblijfplaats.adresseerbaarObjectIdentificatie |
+      | naam                | waarde                                                                  |
+      | type                | RaadpleegMetBurgerservicenummer                                         |
+      | burgerservicenummer | 000000024                                                               |
+      | fields              | postcode,nummeraanduidingIdentificatie,adresseerbaarObjectIdentificatie |
       Dan heeft de response een persoon met alleen de volgende 'verblijfplaats' gegevens
       | naam     | waarde |
       | type     | Adres  |
@@ -48,10 +48,10 @@ Functionaliteit: BAG-identificaties met waarde die niet voldoet aan specificatie
       | identificatiecode verblijfplaats (11.80)   | 0363010000123456 |
       | identificatiecode nummeraanduiding (11.90) | 0363200000123456 |
       Als personen wordt gezocht met de volgende parameters
-      | naam                | waarde                                                                                                               |
-      | type                | RaadpleegMetBurgerservicenummer                                                                                      |
-      | burgerservicenummer | 000000024                                                                                                            |
-      | fields              | verblijfplaats.postcode,verblijfplaats.nummeraanduidingIdentificatie,verblijfplaats.adresseerbaarObjectIdentificatie |
+      | naam                | waarde                                                                  |
+      | type                | RaadpleegMetBurgerservicenummer                                         |
+      | burgerservicenummer | 000000024                                                               |
+      | fields              | postcode,nummeraanduidingIdentificatie,adresseerbaarObjectIdentificatie |
       Dan heeft de response een persoon met alleen de volgende 'verblijfplaats' gegevens
       | naam                             | waarde           |
       | type                             | Adres            |

--- a/features/step_definitions/step_defs.js
+++ b/features/step_definitions/step_defs.js
@@ -163,7 +163,6 @@ const columnNameMap = new Map([
     ['aanduiding bij huisnummer (11.50)', 'huis_nr_aand'],
     ['postcode (11.60)', 'postcode'],
     ['woonplaats (11.70)', 'woon_plaats_naam'],
-    ['woonplaatsnaam (11.70)', 'woon_plaats_naam'],
     ['identificatiecode verblijfplaats (11.80)', 'verblijf_plaats_ident_code'],
     ['identificatiecode nummeraanduiding (11.90)', 'nummer_aand_ident_code'],
 

--- a/features/step_definitions/step_defs.js
+++ b/features/step_definitions/step_defs.js
@@ -163,6 +163,7 @@ const columnNameMap = new Map([
     ['aanduiding bij huisnummer (11.50)', 'huis_nr_aand'],
     ['postcode (11.60)', 'postcode'],
     ['woonplaats (11.70)', 'woon_plaats_naam'],
+    ['woonplaatsnaam (11.70)', 'woon_plaats_naam'],
     ['identificatiecode verblijfplaats (11.80)', 'verblijf_plaats_ident_code'],
     ['identificatiecode nummeraanduiding (11.90)', 'nummer_aand_ident_code'],
 


### PR DESCRIPTION
In de BRP-V komt het (nog) voor dat er incorrecte BAG-identificaties worden toegevoegd. Deze bestaan dan niet uit exact 16 cijfers. RvIG meldt dit aan de betreffende gemeenten om te corrigeren en dit gebeurt ook.

Op dit moment levert de API dan deze identificaties. Bijvoorbeeld:
```
            "verblijfplaats": {
                "type": "Adres",
                "adresseerbaarObjectIdentificatie": "363010000123456 ",
                "nummeraanduidingIdentificatie": "363200000123456 "
            }
```

Dit antwoord voldoet niet aan de API specificaties (pattern voor deze velden) en mag dus niet gestuurd worden.

Ik heb een gba-dev feature gemaakt die beschrijft en test dat in dit geval de BAG identificatie niet geleverd mag worden.

N.B. de test faalt nog, omdat deze invalide waarden nog wel geleverd worden.