### PR TITLE
toevoegen aNummer aan te leveren bij afgevoerde PL

### DIFF
--- a/features/zoek-met-bsn.feature
+++ b/features/zoek-met-bsn.feature
@@ -148,15 +148,15 @@ Rule: Er mag maximaal 20 burgerservicenummers worden opgegeven
 Rule: bij raadplegen van een persoon op burgerservicenummer van een afgevoerde persoonslijst wordt maximaal burgerservicenummer en opschorting bijhouding geleverd
   - wanneer reden opschorting bijhouding (07.67.20) is opgenomen met de waarde "F" (fout), wordt 
       - ten minste opschortingBijhouding.reden geleverd
-      - en indien gevraagd in fields ook burgerservicenummer en opschortingBijhouding.datum
+      - en indien gevraagd in fields ook aNummer, burgerservicenummer en opschortingBijhouding.datum
 
-  Scenario: Raadpleeg persoon op afgevoerde persoonslijst
+  Scenario: Raadpleeg persoon op afgevoerde persoonslijst levert alleen gevraagde aNummer, burgerservicenummer en opschorting
     Gegeven een persoon heeft de volgende 'inschrijving' gegevens
     | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
     | 20220829                             | F                                    |
     En de persoon heeft de volgende 'persoon' gegevens
-    | burgerservicenummer (01.20) | voornamen (02.10) | voorvoegsel (02.30) | geslachtsnaam (02.40) | geboortedatum (03.10) | geslachtsaanduiding (04.10) |
-    | 000000024                   | William           | de                  | Vries                 | 20040526              | M                           |
+    | anummer (01.10) | burgerservicenummer (01.20) | voornamen (02.10) | voorvoegsel (02.30) | geslachtsnaam (02.40) | geboortedatum (03.10) | geslachtsaanduiding (04.10) |
+    | 0123456789       | 000000024                   | William           | de                  | Vries                 | 20040526              | M                           |
     En de persoon heeft een ouder '1' met de volgende gegevens
     | burgerservicenummer (01.20) | voornamen (02.10) | voorvoegsel (02.30) | geslachtsnaam (02.40) | geboortedatum (03.10) | geslachtsaanduiding (04.10) |
     | 000000036                   | Corry             | van                 | Zon                   | 19730428              | V                           |
@@ -167,12 +167,42 @@ Rule: bij raadplegen van een persoon op burgerservicenummer van een afgevoerde p
     #| gemeente van inschrijving (09.10) | functieAdres (10.10) | datum aanvang adreshouding (10.30) | straatnaam (11.10) | huisnummer (11.20) | postcode (11.60) |
     #| 0518                              | W                    | 20170423                           | Spui               | 70                 | 1234AA           |
     Als personen wordt gezocht met de volgende parameters
-    | naam                | waarde                                                                                                            |
-    | type                | RaadpleegMetBurgerservicenummer                                                                                   |
-    | burgerservicenummer | 000000024                                                                                                         |
-    | fields              | burgerservicenummer,naam,geboorte,leeftijd,geslacht,ouders,nationaliteiten,verblijfplaats,gemeenteVanInschrijving |
+    | naam                | waarde                                                                                                                                            |
+    | type                | RaadpleegMetBurgerservicenummer                                                                                                                   |
+    | burgerservicenummer | 000000024                                                                                                                                         |
+    | fields              | aNummer, burgerservicenummer,naam,geboorte,leeftijd,geslacht,ouders,nationaliteiten,verblijfplaats,gemeenteVanInschrijving, opschortingBijhouding |
     Dan heeft de response een persoon met de volgende gegevens
-    | naam                                     | waarde    |
-    | burgerservicenummer                      | 000000024 |
-    | opschortingBijhouding.reden.code         | F         |
-    | opschortingBijhouding.reden.omschrijving | fout      |
+    | naam                                     | waarde           |
+    | aNummer                                  | 0123456789       |
+    | burgerservicenummer                      | 000000024        |
+    | opschortingBijhouding.reden.code         | F                |
+    | opschortingBijhouding.reden.omschrijving | fout             |
+    | opschortingBijhouding.datum.type         | Datum            |
+    | opschortingBijhouding.datum.datum        | 2022-08-29       |
+    | opschortingBijhouding.datum.langFormaat  | 29 augustus 2022 |
+
+  Scenario: Raadpleeg persoon op afgevoerde persoonslijst levert alleen opschorting reden
+    Gegeven een persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | F                                    |
+    En de persoon heeft de volgende 'persoon' gegevens
+    | anummer (01.10) | burgerservicenummer (01.20) | voornamen (02.10) | voorvoegsel (02.30) | geslachtsnaam (02.40) | geboortedatum (03.10) | geslachtsaanduiding (04.10) |
+    | 0123456789       | 000000024                   | William           | de                  | Vries                 | 20040526              | M                           |
+    En de persoon heeft een ouder '1' met de volgende gegevens
+    | burgerservicenummer (01.20) | voornamen (02.10) | voorvoegsel (02.30) | geslachtsnaam (02.40) | geboortedatum (03.10) | geslachtsaanduiding (04.10) |
+    | 000000036                   | Corry             | van                 | Zon                   | 19730428              | V                           |
+    En de persoon heeft een 'nationaliteit' met de volgende gegevens
+    | nationaliteit (05.10) | reden opnemen (63.10) | datum ingang geldigheid (85.10) |
+    | 0001                  | 001                   | 20040603                        |
+    #En de persoon heeft de volgende 'verblijfplaats' gegevens
+    #| gemeente van inschrijving (09.10) | functieAdres (10.10) | datum aanvang adreshouding (10.30) | straatnaam (11.10) | huisnummer (11.20) | postcode (11.60) |
+    #| 0518                              | W                    | 20170423                           | Spui               | 70                 | 1234AA           |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                                                                                                            |
+    | type                | RaadpleegMetBurgerservicenummer                                                                                                                   |
+    | burgerservicenummer | 000000024                                                                                                                                         |
+    | fields              | naam,geboorte,leeftijd,geslacht,ouders,nationaliteiten,verblijfplaats,gemeenteVanInschrijving |
+    Dan heeft de response een persoon met de volgende gegevens
+    | naam                                     | waarde           |
+    | opschortingBijhouding.reden.code         | F                |
+    | opschortingBijhouding.reden.omschrijving | fout             |


### PR DESCRIPTION
Bij leveren afgevoerde PL op raadplegen met bsn mag naast burgerservicenummer en opschorting ook A-nummer geleverd worden. Dit toegevoegd aan betreffende feature.

Ook een scenario toegevoegd waarbij die gegevens niet gevraagd zijn, wel andere gegevens. Dan wordt alleen opschorting reden geleverd.

N.B. het viel me op dat voor A-nummer de benaming "nummer (01.10)" wordt gebruikt. Was er niet afgesproken zoveel mogelijk de benaming uit het LO te gebruiken in de Gegeven stappen? Dus "A-nummer (01.10)"