### PR TITLE
verwijderen functieAdres uit verblijfplaatsOnbekend

### DIFF
--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -1276,9 +1276,6 @@
         }, {
           "type" : "object",
           "properties" : {
-            "functieAdres" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
             "inOnderzoek" : {
               "$ref" : "#/components/schemas/VerblijfplaatsInOnderzoekBeperkt"
             }
@@ -2073,15 +2070,11 @@
         } ]
       },
       "VerblijfplaatsOnbekend" : {
-        "description" : "* **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten. Wordt gevuld op basis van de waarden die voorkomen in de tabel \"Gemeenten\" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats\n",
         "allOf" : [ {
           "$ref" : "#/components/schemas/AbstractVerblijfplaats"
         }, {
           "type" : "object",
           "properties" : {
-            "functieAdres" : {
-              "$ref" : "#/components/schemas/Waardetabel"
-            },
             "datumVan" : {
               "$ref" : "#/components/schemas/AbstractDatum"
             },
@@ -2104,9 +2097,6 @@
               "type" : "boolean"
             },
             "datumVan" : {
-              "type" : "boolean"
-            },
-            "functieAdres" : {
               "type" : "boolean"
             },
             "datumIngangGeldigheid" : {

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -994,8 +994,6 @@ components:
       - $ref: '#/components/schemas/AbstractVerblijfplaatsBeperkt'
       - type: object
         properties:
-          functieAdres:
-            $ref: '#/components/schemas/Waardetabel'
           inOnderzoek:
             $ref: '#/components/schemas/VerblijfplaatsInOnderzoekBeperkt'
     LocatieBeperkt:
@@ -1564,14 +1562,10 @@ components:
           functieAdres:
             type: boolean
     VerblijfplaatsOnbekend:
-      description: |
-        * **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten. Wordt gevuld op basis van de waarden die voorkomen in de tabel "Gemeenten" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats
       allOf:
       - $ref: '#/components/schemas/AbstractVerblijfplaats'
       - type: object
         properties:
-          functieAdres:
-            $ref: '#/components/schemas/Waardetabel'
           datumVan:
             $ref: '#/components/schemas/AbstractDatum'
           datumIngangGeldigheid:
@@ -1586,8 +1580,6 @@ components:
           type:
             type: boolean
           datumVan:
-            type: boolean
-          functieAdres:
             type: boolean
           datumIngangGeldigheid:
             type: boolean

--- a/specificatie/verblijfplaats.yaml
+++ b/specificatie/verblijfplaats.yaml
@@ -166,8 +166,6 @@ components:
         - $ref: '#/components/schemas/AbstractVerblijfplaatsBeperkt'
         - type: object
           properties:
-            functieAdres:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
             inOnderzoek:
               $ref: '#/components/schemas/VerblijfplaatsInOnderzoekBeperkt'
     LocatieBeperkt:
@@ -289,14 +287,10 @@ components:
             inOnderzoek:
               $ref: '#/components/schemas/LocatieInOnderzoek'
     VerblijfplaatsOnbekend:
-      description: |
-        * **gemeenteVanInschrijving** : de gemeente waar de persoon verblijft en is ingeschreven. De code kan voorloopnullen bevatten. Wordt gevuld op basis van de waarden die voorkomen in de tabel "Gemeenten" voor een gemeente in Nederland of de omschrijving van een buitenlandse plaats
       allOf:
         - $ref: '#/components/schemas/AbstractVerblijfplaats'
         - type: object
           properties:
-            functieAdres:
-              $ref: 'common.yaml#/components/schemas/Waardetabel'
             datumVan:
               $ref: 'datum.yaml#/components/schemas/AbstractDatum'
             datumIngangGeldigheid:
@@ -416,8 +410,6 @@ components:
             type:
               type: boolean
             datumVan:
-              type: boolean
-            functieAdres:
               type: boolean
             datumIngangGeldigheid:
               type: boolean


### PR DESCRIPTION
Aangezien we type VerblijfplaatsOnbekend nu alleen nog bepalen op basis van land (08.13.10) == 0000, kan functieAdres geen waarde hebben. Die komt alleen voor bij Adres en Locatie.

Daarom ook functieAdres verwijderd uit specificaties voor VerblijfplaatsOnbekend en VerblijfplaatsOnbekendBeperkt