### PR TITLE
fix(specs): twee inOnderzoek properties in gegenereerde Geboorte code

### DIFF
--- a/specificatie/geboorte.yaml
+++ b/specificatie/geboorte.yaml
@@ -20,13 +20,18 @@ components:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
             plaats:
               $ref: 'common.yaml#/components/schemas/Waardetabel'
-    GeboorteBeperkt:
+    GeboorteBasis:
       type: object
       properties:
         datum:
           $ref: 'datum.yaml#/components/schemas/AbstractDatum'
-        inOnderzoek:
-          $ref: '#/components/schemas/GeboorteInOnderzoekBeperkt'
+    GeboorteBeperkt:
+      allOf:
+        - $ref: '#/components/schemas/GeboorteBasis'
+        - type: object
+          properties:
+            inOnderzoek:
+              $ref: '#/components/schemas/GeboorteInOnderzoekBeperkt'
     Geboorte:
       description: |
         Gegevens over de geboorte.
@@ -34,7 +39,7 @@ components:
         * **land** - land waar de persoon is geboren. Wordt gevuld met waarden uit de tabel 'Landen' (zie Haal-Centraal-BRP-tabellen-bevragen API).
         * **plaats** - gemeente waar de persoon is geboren. Wordt gevuld met waarden uit de tabel "Gemeenten" voor een gemeente in Nederland of als de persoon is geboren buiten Nederland de omschrijving van een buitenlandse plaatsnaam of aanduiding.
       allOf:
-        - $ref: '#/components/schemas/GeboorteBeperkt'
+        - $ref: '#/components/schemas/GeboorteBasis'
         - type: object
           properties:
             land:

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -1002,13 +1002,22 @@
         "example" : "0518200000366054"
       },
       "GeboorteBeperkt" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/GeboorteBasis"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "inOnderzoek" : {
+              "$ref" : "#/components/schemas/GeboorteInOnderzoekBeperkt"
+            }
+          }
+        } ]
+      },
+      "GeboorteBasis" : {
         "type" : "object",
         "properties" : {
           "datum" : {
             "$ref" : "#/components/schemas/AbstractDatum"
-          },
-          "inOnderzoek" : {
-            "$ref" : "#/components/schemas/GeboorteInOnderzoekBeperkt"
           }
         }
       },
@@ -1714,7 +1723,7 @@
       "Geboorte" : {
         "description" : "Gegevens over de geboorte.\n* **datum** - datum waarop de persoon is geboren.\n* **land** - land waar de persoon is geboren. Wordt gevuld met waarden uit de tabel 'Landen' (zie Haal-Centraal-BRP-tabellen-bevragen API).\n* **plaats** - gemeente waar de persoon is geboren. Wordt gevuld met waarden uit de tabel \"Gemeenten\" voor een gemeente in Nederland of als de persoon is geboren buiten Nederland de omschrijving van een buitenlandse plaatsnaam of aanduiding.\n",
         "allOf" : [ {
-          "$ref" : "#/components/schemas/GeboorteBeperkt"
+          "$ref" : "#/components/schemas/GeboorteBasis"
         }, {
           "type" : "object",
           "properties" : {

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -792,12 +792,17 @@ components:
         Unieke identificatie van een nummeraanduiding (en het bijbehorende adres) in de BAG.
       example: "0518200000366054"
     GeboorteBeperkt:
+      allOf:
+      - $ref: '#/components/schemas/GeboorteBasis'
+      - type: object
+        properties:
+          inOnderzoek:
+            $ref: '#/components/schemas/GeboorteInOnderzoekBeperkt'
+    GeboorteBasis:
       type: object
       properties:
         datum:
           $ref: '#/components/schemas/AbstractDatum'
-        inOnderzoek:
-          $ref: '#/components/schemas/GeboorteInOnderzoekBeperkt'
     GeboorteInOnderzoekBeperkt:
       allOf:
       - $ref: '#/components/schemas/InOnderzoek'
@@ -1307,7 +1312,7 @@ components:
         * **land** - land waar de persoon is geboren. Wordt gevuld met waarden uit de tabel 'Landen' (zie Haal-Centraal-BRP-tabellen-bevragen API).
         * **plaats** - gemeente waar de persoon is geboren. Wordt gevuld met waarden uit de tabel "Gemeenten" voor een gemeente in Nederland of als de persoon is geboren buiten Nederland de omschrijving van een buitenlandse plaatsnaam of aanduiding.
       allOf:
-      - $ref: '#/components/schemas/GeboorteBeperkt'
+      - $ref: '#/components/schemas/GeboorteBasis'
       - type: object
         properties:
           land:


### PR DESCRIPTION
Door het toevoegen van de inOnderzoek property aan GeboorteBeperkt en doordat Geboorte van GeboorteBeperkt afleidt, krijgt Geboorte component twee inOnderzoek properties in gegenereerde code. Dit is niet zichtbaar in SwaggerUI.
Het probleem is opgelost door de GeboorteBasis component te definieren en Geboorte en GeboorteBeperkt hiervan af te leiden